### PR TITLE
feat: 모바일 반응형 레이아웃 및 사용자 경험 개선

### DIFF
--- a/apps/web/src/components/layout/Header/constants.ts
+++ b/apps/web/src/components/layout/Header/constants.ts
@@ -1,0 +1,47 @@
+import {
+  MdOutlineAccessTime,
+  MdOutlineCheckCircle,
+  MdOutlineList,
+} from 'react-icons/md';
+
+// 네비게이션 메뉴 아이템
+export interface NavItem {
+  name: string;
+  href: string;
+}
+
+export const navigation: NavItem[] = [
+  { name: '여행 목록', href: '/travel-list' },
+  { name: '요금제', href: '/price' },
+  { name: 'FAQ', href: '/faq' },
+  { name: '문의하기', href: '/contact' },
+];
+
+// 여행 계획 필터 옵션
+export const filterOptions = [
+  { key: 'all', label: '전체', icon: MdOutlineList },
+  { key: 'in-progress', label: '진행 중', icon: MdOutlineAccessTime },
+  { key: 'completed', label: '완료', icon: MdOutlineCheckCircle },
+] as const;
+
+// 여행 계획 데이터 타입
+export interface TravelPlan {
+  id: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  status: 'all' | 'in-progress' | 'completed';
+  participantAvatars: string[];
+}
+
+// 임시 여행 계획 데이터
+export const mockTravelPlans: TravelPlan[] = [
+  {
+    id: '1',
+    title: '제주도 여행',
+    startDate: '2024-03-15',
+    endDate: '2024-03-18',
+    status: 'in-progress',
+    participantAvatars: ['/avatar1.jpg', '/avatar2.jpg'],
+  },
+];

--- a/apps/web/src/components/layout/LayoutWrapper.tsx
+++ b/apps/web/src/components/layout/LayoutWrapper.tsx
@@ -4,7 +4,7 @@ import { PropsWithChildren, useState } from 'react';
 
 import { usePathname } from 'next/navigation';
 
-import { useSession } from '@/hooks/useSession';
+import { useMobile, useSession } from '@/hooks';
 
 import { Footer } from './Footer';
 import { Header, SimpleHeader } from './Header';
@@ -16,6 +16,7 @@ import { Sidebar } from './Sidebar';
  */
 const LayoutWrapper = ({ children }: PropsWithChildren) => {
   const pathname = usePathname();
+  const isMobile = useMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { isAuthenticated, isSignUpCompleted } = useSession();
 
@@ -23,8 +24,9 @@ const LayoutWrapper = ({ children }: PropsWithChildren) => {
   const isAuthPage =
     pathname.includes('log-in') || pathname.includes('sign-up');
 
-  // 사이드바를 표시할지 결정 (로그인 완료된 사용자만)
-  const shouldShowSidebar = isAuthenticated && isSignUpCompleted && !isAuthPage;
+  // 사이드바를 표시할지 결정 (로그인 완료된 사용자이고 데스크탑일 때만)
+  const shouldShowSidebar =
+    isAuthenticated && isSignUpCompleted && !isAuthPage && !isMobile;
 
   const handleSidebarToggle = () => {
     setSidebarOpen(!sidebarOpen);
@@ -39,10 +41,11 @@ const LayoutWrapper = ({ children }: PropsWithChildren) => {
         <Header
           sidebarOpen={sidebarOpen}
           shouldShowSidebar={shouldShowSidebar}
+          onSidebarToggle={handleSidebarToggle}
         />
       )}
 
-      {/* 사이드바 (로그인 완료된 사용자만) */}
+      {/* 사이드바 (로그인 완료된 사용자이고 데스크탑일 때만) */}
       {shouldShowSidebar && (
         <Sidebar isOpen={sidebarOpen} onToggle={handleSidebarToggle} />
       )}
@@ -50,7 +53,11 @@ const LayoutWrapper = ({ children }: PropsWithChildren) => {
       {/* 메인 콘텐츠 영역 */}
       <div
         className={`mx-auto mt-[64px] min-h-dvh transition-all duration-300 ${
-          shouldShowSidebar ? (sidebarOpen ? 'sm:pl-80' : 'sm:pl-16') : ''
+          shouldShowSidebar && !isMobile
+            ? sidebarOpen
+              ? 'sm:pl-80'
+              : 'sm:pl-16'
+            : ''
         }`}
       >
         {children}

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,3 +1,5 @@
 // 특정 항목만 명시적으로 내보내기
+export { useSession } from './useSession';
 export { useModal } from './useModal';
 export { useToast } from './useToast';
+export { useMobile } from './useMobile';

--- a/apps/web/src/hooks/useMobile.ts
+++ b/apps/web/src/hooks/useMobile.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * 모바일/데스크탑 상태를 감지하는 커스텀 훅
+ * @param breakpoint - 모바일과 데스크탑을 구분하는 브레이크포인트 (기본값: 768px)
+ * @returns isMobile - 현재 화면이 모바일인지 여부
+ */
+export const useMobile = (breakpoint: number = 768) => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    // 초기 상태 설정
+    const checkIsMobile = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+
+    // 첫 렌더링 시 체크
+    checkIsMobile();
+
+    // 리사이즈 이벤트 리스너 등록
+    window.addEventListener('resize', checkIsMobile);
+
+    // 클린업
+    return () => {
+      window.removeEventListener('resize', checkIsMobile);
+    };
+  }, [breakpoint]);
+
+  return isMobile;
+};

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -16,18 +16,18 @@ type UserProfile = {
 };
 
 // 회원가입 완료 상태 타입
-type SignUpStatus = 'completed' | 'incomplete' | 'loading';
+type SignUpStatus = 'completed' | 'incomplete' | 'unauthenticated';
 
 export const useSession = () => {
   const [loading, setLoading] = useState(true);
   const [session, setSession] = useState<Session | null>(null);
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [error, setError] = useState<Error | null>(null);
-  const [signUpStatus, setSignUpStatus] = useState<SignUpStatus>('loading');
+  const [signUpStatus, setSignUpStatus] =
+    useState<SignUpStatus>('unauthenticated');
 
   const router = useRouter();
   const pathname = usePathname();
-  const supabase = createClient();
 
   // 리다이렉트 예외 페이지들 (회원가입 미완료여도 접근 가능한 페이지)
   const excludedPaths = useMemo(
@@ -35,50 +35,56 @@ export const useSession = () => {
     []
   );
 
-  // 사용자 프로필 정보 가져오기
-  const fetchUserProfile = useCallback(
-    async (user: User) => {
-      try {
-        const { data: profile, error } = await supabase
-          .from('user_profiles')
-          .select('nickname, profile_image_url')
-          .eq('id', user.id)
-          .single();
+  // 사용자 프로필 정보 가져오기 (의존성 제거)
+  const fetchUserProfile = useCallback(async (user: User) => {
+    try {
+      const supabaseClient = createClient();
+      const { data: profile, error } = await supabaseClient
+        .from('user_profiles')
+        .select('nickname, profile_image_url')
+        .eq('id', user.id)
+        .single();
 
-        if (error) {
-          // 프로필이 없는 경우 (새 사용자)
-          const basicUserData = {
-            id: user.id,
-            email: user.email,
-          };
-          setUserProfile(basicUserData);
-          setSignUpStatus('incomplete');
-          // console.log('회원가입 미완료 사용자 감지:', basicUserData);
-        } else {
-          // 프로필이 있는 경우 (기존 사용자)
-          const userData = {
-            id: user.id,
-            email: user.email,
-            nickname: profile.nickname,
-            profile_image_url: profile.profile_image_url,
-          };
-          setUserProfile(userData);
-          setSignUpStatus('completed');
-          // console.log('회원가입 완료된 사용자:', userData);
-        }
-      } catch {
-        // console.error('프로필 fetch 중 오류');
-        setSignUpStatus('incomplete'); // 오류 발생 시 미완료로 처리
+      if (error) {
+        // 프로필이 없는 경우 (새 사용자)
+        const basicUserData = {
+          id: user.id,
+          email: user.email,
+        };
+        setUserProfile(basicUserData);
+        setSignUpStatus('incomplete');
+      } else {
+        // 프로필이 있는 경우 (기존 사용자)
+        const userData = {
+          id: user.id,
+          email: user.email,
+          nickname: profile.nickname,
+          profile_image_url: profile.profile_image_url,
+        };
+        setUserProfile(userData);
+        setSignUpStatus('completed');
       }
-    },
-    [supabase]
-  );
+    } catch (fetchError) {
+      // 오류 발생 시에도 기본 사용자 데이터 설정
+      const basicUserData = {
+        id: user.id,
+        email: user.email,
+      };
+      setUserProfile(basicUserData);
+      setSignUpStatus('incomplete');
+    }
+  }, []);
 
   useEffect(() => {
-    const fetchSession = async () => {
+    let isMounted = true;
+    let authSubscription: { unsubscribe: () => void } | null = null;
+
+    const initializeAuth = async () => {
       try {
-        setLoading(true);
+        const supabase = createClient();
         const { data, error } = await supabase.auth.getSession();
+
+        if (!isMounted) return;
 
         if (error) {
           throw error;
@@ -90,7 +96,8 @@ export const useSession = () => {
         if (data.session?.user) {
           await fetchUserProfile(data.session.user);
         } else {
-          setSignUpStatus('loading'); // 로그인되지 않은 상태
+          setUserProfile(null);
+          setSignUpStatus('unauthenticated');
         }
 
         // Auth state 변경 리스너 설정
@@ -98,32 +105,56 @@ export const useSession = () => {
           data: { subscription },
         } = supabase.auth.onAuthStateChange(
           async (_event: AuthChangeEvent, newSession: Session | null) => {
+            if (!isMounted) return;
+
             setSession(newSession);
             if (newSession?.user) {
               await fetchUserProfile(newSession.user);
             } else {
               setUserProfile(null);
-              setSignUpStatus('loading');
+              setSignUpStatus('unauthenticated');
             }
           }
         );
 
-        return () => {
-          subscription.unsubscribe();
-        };
+        authSubscription = subscription;
       } catch (err) {
+        if (!isMounted) return;
         setError(
           err instanceof Error
             ? err
             : new Error('세션 조회 중 오류가 발생했습니다')
         );
+        // 에러 시에도 기본 상태로 설정
+        setSession(null);
+        setUserProfile(null);
+        setSignUpStatus('unauthenticated');
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
-    fetchSession();
-  }, [supabase, fetchUserProfile]);
+    // 타임아웃 보호 (10초 후 강제 로딩 완료)
+    const loadingTimeout = setTimeout(() => {
+      if (isMounted && loading) {
+        setLoading(false);
+        setSignUpStatus('unauthenticated');
+      }
+    }, 10000);
+
+    initializeAuth();
+
+    // 클린업 함수
+    return () => {
+      isMounted = false;
+      clearTimeout(loadingTimeout);
+      if (authSubscription) {
+        authSubscription.unsubscribe();
+      }
+    };
+  }, []); // 의존성 배열 비우기
 
   // 회원가입 완료 여부에 따른 리다이렉트 처리
   useEffect(() => {
@@ -136,15 +167,18 @@ export const useSession = () => {
     if (session && signUpStatus === 'incomplete') {
       router.push('/sign-up');
     }
-  }, [
-    session,
-    signUpStatus,
-    loading,
-    pathname,
-    router,
-    excludedPaths,
-    fetchUserProfile,
-  ]);
+  }, [session, signUpStatus, loading, pathname, router, excludedPaths]);
+
+  const signOut = useCallback(async () => {
+    try {
+      const supabase = createClient();
+      await supabase.auth.signOut();
+      setUserProfile(null);
+      setSignUpStatus('unauthenticated');
+    } catch (err) {
+      console.error('로그아웃 중 오류:', err);
+    }
+  }, []);
 
   return {
     session,
@@ -155,10 +189,6 @@ export const useSession = () => {
     isAuthenticated: !!session,
     isSignUpCompleted: signUpStatus === 'completed',
     isSignUpIncomplete: signUpStatus === 'incomplete',
-    signOut: async () => {
-      await supabase.auth.signOut();
-      setUserProfile(null);
-      setSignUpStatus('loading');
-    },
+    signOut,
   };
 };


### PR DESCRIPTION
## 📝 설명
모바일 환경에서의 사용자 경험을 개선하기 위해 반응형 레이아웃을 구현하고, 헤더 컴포넌트의 로딩 상태 관리 문제를 해결했습니다. 데스크탑에서는 기존 사이드바를 유지하면서, 모바일에서는 헤더 기반의 네비게이션으로 전환하여 화면 공간을 효율적으로 활용할 수 있도록 개선했습니다.

### 🚀 주요 변경사항
**모바일/데스크탑 상태 감지 시스템 구축**
- `useMobile` 커스텀 훅을 개발하여 768px 기준으로 모바일/데스크탑을 구분합니다.
- 실시간 화면 크기 변경에 대응하는 이벤트 리스너를 구현했습니다.

**모바일 우선 반응형 레이아웃 구현**
- 모바일에서는 사이드바를 완전히 숨기고 헤더가 전체 너비를 차지하도록 수정했습니다.
- 데스크탑에서는 기존 사이드바 레이아웃을 그대로 유지했습니다.

**헤더 컴포넌트 구조 개선**
- 상수와 타입 정의를 `constants.ts`로 분리시켰습니다.

**useSession 훅 안정성 개선**
- 의존성 문제를 해결하여 무한 리렌더링을 방지했습니다.
- 10초 타임아웃을 추가하여 로딩 상태가 무한히 지속되는 문제를 해결했습니다.