### PR TITLE
feat(travel): 여행 계획 UX/로직 개선

### DIFF
--- a/apps/web/src/app/api/blocks/[id]/move/route.ts
+++ b/apps/web/src/app/api/blocks/[id]/move/route.ts
@@ -81,14 +81,11 @@ export async function POST(
     }
 
     // Supabase RPC 함수 호출하여 블록 이동
-    const { data: result, error: moveError } = await supabase.rpc(
-      'move_travel_block',
-      {
-        block_id: blockId,
-        new_day_number: newDayNumber,
-        new_order_index: newOrderIndex,
-      }
-    );
+    const { error: moveError } = await supabase.rpc('move_travel_block', {
+      block_id: blockId,
+      new_day_number: newDayNumber,
+      new_order_index: newOrderIndex,
+    });
 
     if (moveError) {
       console.error('Block move error:', moveError);

--- a/apps/web/src/app/api/blocks/route.ts
+++ b/apps/web/src/app/api/blocks/route.ts
@@ -212,7 +212,7 @@ export async function POST(request: NextRequest) {
     }
 
     // 활동 로그 생성 (스키마 준수: type/content)
-    const { data: activityRow, error: activityError } = await supabase
+    const { error: activityError } = await supabase
       .from('travel_activities')
       .insert({
         plan_id,

--- a/apps/web/src/app/api/todos/route.ts
+++ b/apps/web/src/app/api/todos/route.ts
@@ -111,12 +111,17 @@ export async function GET(request: Request) {
     }
 
     // 사용자 정보 조회 (profiles 테이블이 있는 경우)
-    const usersMap = new Map<string, any>();
+    type UserProfile = {
+      id: string;
+      nickname?: string;
+      profile_image_url?: string;
+    };
+    const usersMap = new Map<string, UserProfile>();
     try {
       const userIds = new Set<string>();
-      todos.forEach((todo: any) => {
-        if (todo.assigned_user_id) userIds.add(todo.assigned_user_id);
-        if (todo.created_by) userIds.add(todo.created_by);
+      todos.forEach((todo) => {
+        if (todo.assigned_user_id) userIds.add(todo.assigned_user_id as string);
+        if (todo.created_by) userIds.add(todo.created_by as string);
       });
 
       if (userIds.size > 0) {
@@ -126,8 +131,8 @@ export async function GET(request: Request) {
           .in('id', Array.from(userIds));
 
         if (!usersError && users) {
-          users.forEach((u: any) => {
-            usersMap.set(u.id, u);
+          users.forEach((u) => {
+            usersMap.set(u.id as string, u as UserProfile);
           });
         }
       }
@@ -136,12 +141,12 @@ export async function GET(request: Request) {
     }
 
     // 투두 데이터에 사용자 정보 추가
-    const todosWithUsers = todos.map((todo: any) => ({
+    const todosWithUsers = todos.map((todo) => ({
       ...todo,
       assignee: todo.assigned_user_id
-        ? usersMap.get(todo.assigned_user_id)
+        ? usersMap.get(todo.assigned_user_id as string) || null
         : null,
-      creator: usersMap.get(todo.created_by),
+      creator: usersMap.get(todo.created_by as string) || null,
     }));
 
     return NextResponse.json({ todos: todosWithUsers });
@@ -247,7 +252,12 @@ export async function POST(request: Request) {
     }
 
     // 사용자 정보 조회 및 추가
-    const usersMap = new Map<string, any>();
+    type UserProfile = {
+      id: string;
+      nickname?: string;
+      profile_image_url?: string;
+    };
+    const usersMap = new Map<string, UserProfile>();
     try {
       const userIds = new Set<string>();
       if (newTodo.assigned_user_id) userIds.add(newTodo.assigned_user_id);
@@ -260,8 +270,8 @@ export async function POST(request: Request) {
           .in('id', Array.from(userIds));
 
         if (!usersError && users) {
-          users.forEach((u: any) => {
-            usersMap.set(u.id, u);
+          users.forEach((u) => {
+            usersMap.set(u.id as string, u as UserProfile);
           });
         }
       }

--- a/apps/web/src/app/sign-up/view.tsx
+++ b/apps/web/src/app/sign-up/view.tsx
@@ -14,11 +14,7 @@ import { Card } from '@/components';
 import LocationInput from '@/components/travel/inputs/LocationInput';
 import { useToast } from '@/hooks';
 import { createClient } from '@/lib/supabase/client/supabase';
-import type {
-  PreferredDestination,
-  TravelStyle,
-  UserProfile,
-} from '@/types/user/user';
+import type { TravelStyle, UserProfile } from '@/types/user/user';
 
 import { FILE_UPLOAD_LIMITS, TOTAL_STEPS, TRAVEL_STYLES } from './constants';
 import { useImageUpload } from './hooks/useImageUpload';
@@ -77,14 +73,6 @@ const SignUpView = () => {
       }
 
       setUser(session.user);
-
-      // 사용자 정보를 콘솔에 출력
-      console.log('🔐 현재 로그인된 사용자 정보:');
-      console.log('👤 사용자 전체 정보:', session.user);
-      console.log('🆔 사용자 ID:', session.user.id);
-      console.log('📧 이메일:', session.user.email);
-      console.log('🔗 인증 제공자:', session.user.app_metadata?.provider);
-      console.log('📊 사용자 메타데이터:', session.user.user_metadata);
 
       // 소셜 로그인 정보에서 기본값 설정
       if (session.user.user_metadata) {

--- a/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
+++ b/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
@@ -394,7 +394,7 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
 
               <button
                 onClick={onReadinessClick}
-                className='w-full cursor-pointer rounded-lg p-2 transition-all duration-200 hover:bg-gray-50 sm:p-3'
+                className='w-full rounded-lg p-2 transition-all duration-200 sm:p-3'
                 disabled={!onReadinessClick || readinessLoading}
               >
                 <Progress
@@ -402,15 +402,6 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
                   size='medium'
                   colorTheme={status.color as ProgressColorTheme}
                 />
-                <div className='mt-2 flex items-center space-x-2 text-sm text-gray-500'>
-                  <IoCheckmarkCircleOutline className='h-4 w-4' />
-                  <span>{status.message}</span>
-                  {onReadinessClick && (
-                    <span className='ml-auto text-xs text-blue-500'>
-                      상세보기 →
-                    </span>
-                  )}
-                </div>
               </button>
 
               {/* 추천사항 */}
@@ -470,7 +461,7 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
               ) : (
                 <button
                   onClick={onBudgetClick}
-                  className='w-full cursor-pointer rounded-xl bg-gray-50 p-3 transition-all duration-200 hover:bg-gray-100 sm:p-4'
+                  className='w-full rounded-xl bg-gray-50 p-3 transition-all duration-200 sm:p-4'
                   disabled={!onBudgetClick || budgetLoading}
                 >
                   {budgetLoading ? (
@@ -487,7 +478,7 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
                       {/* 상단 요약: 사용/남음 (이중 통화 표시) */}
                       <div className='mb-3 grid grid-cols-1 gap-3 sm:grid-cols-2'>
                         {/* 사용 */}
-                        <div className='rounded-xl border border-gray-100 bg-gray-50 p-3'>
+                        <div className='rounded-xl border border-gray-100 bg-white p-3'>
                           <Typography
                             variant='caption'
                             className='text-gray-500'
@@ -528,7 +519,7 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
                           </div>
                         </div>
                         {/* 남음 */}
-                        <div className='rounded-xl border border-gray-100 bg-gray-50 p-3 text-right'>
+                        <div className='rounded-xl border border-gray-100 bg-white p-3'>
                           <Typography
                             variant='caption'
                             className='text-gray-500'
@@ -589,38 +580,55 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
                         </span>
                       </div>
 
-                      {/* 총 예산: 원래 통화 / 변환 통화 */}
-                      <div className='flex items-center justify-between'>
+                      {/* 총 예산: 우측 정렬 숫자, 하단 환율 안내 */}
+                      <div className='flex items-start justify-between'>
                         <div className='flex items-center space-x-2'>
                           <IoWalletOutline className='h-4 w-4 text-green-600' />
                           <Typography variant='body2' className='text-gray-700'>
-                            총 예산{' '}
-                            {
-                              budgetInfo.originalBudgetInfo
-                                .formattedTargetBudget
-                            }
-                            {budgetInfo.currency !==
-                              budgetInfo.originalCurrency && (
-                              <> / {budgetInfo.formattedTargetBudget}</>
-                            )}
+                            총 예산
                           </Typography>
                         </div>
-                        {budgetInfo.currency !==
-                          budgetInfo.originalCurrency && (
-                          <Typography
-                            variant='caption'
-                            className='text-gray-400'
-                          >
-                            환율 기준: 1 {budgetInfo.originalCurrency} ≈{' '}
-                            {budgetInfo.exchangeRate.toFixed(2)}{' '}
-                            {budgetInfo.currency}
-                          </Typography>
-                        )}
-                        {onBudgetClick && (
-                          <span className='text-xs text-blue-500'>
-                            상세보기 →
-                          </span>
-                        )}
+                        <div className='text-right'>
+                          <div className='flex flex-wrap items-baseline justify-end gap-1'>
+                            <Typography
+                              variant='h6'
+                              className='break-all font-mono font-extrabold text-gray-900'
+                            >
+                              {
+                                budgetInfo.originalBudgetInfo
+                                  .formattedTargetBudget
+                              }
+                            </Typography>
+                            <span className='shrink-0 rounded-full bg-white px-2 py-0.5 text-[10px] text-gray-600'>
+                              {budgetInfo.originalCurrency}
+                            </span>
+                          </div>
+                          {budgetInfo.currency !==
+                            budgetInfo.originalCurrency && (
+                            <div className='flex flex-wrap items-baseline justify-end gap-1'>
+                              <Typography
+                                variant='h6'
+                                className='break-all font-mono font-extrabold text-gray-900'
+                              >
+                                {budgetInfo.formattedTargetBudget}
+                              </Typography>
+                              <span className='shrink-0 rounded-full bg-white px-2 py-0.5 text-[10px] text-gray-600'>
+                                {budgetInfo.currency}
+                              </span>
+                            </div>
+                          )}
+                          {budgetInfo.currency !==
+                            budgetInfo.originalCurrency && (
+                            <Typography
+                              variant='caption'
+                              className='text-gray-400'
+                            >
+                              환율 기준: 1 {budgetInfo.originalCurrency} ≈{' '}
+                              {budgetInfo.exchangeRate.toFixed(2)}{' '}
+                              {budgetInfo.currency}
+                            </Typography>
+                          )}
+                        </div>
                       </div>
                     </>
                   )}

--- a/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
+++ b/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
@@ -2,7 +2,6 @@
 
 import {
   IoAddOutline,
-  IoCalendarOutline,
   IoDownloadOutline,
   IoSettingsOutline,
   IoTimeOutline,
@@ -19,7 +18,8 @@ import {
 
 import { useBudgetWithExchange } from '@/hooks/useBudgetWithExchange';
 import { usePlanningProgress } from '@/hooks/usePlanningProgress';
-import { calculateDDayWithEnd, formatTripNightsDays } from '@/lib/travel-utils';
+
+// import { calculateDDayWithEnd } from '@/lib/travel-utils';
 
 import { SharedTodoWidget } from './SharedTodoWidget';
 
@@ -81,8 +81,6 @@ interface BriefingBoardProps {
 
 export const BriefingBoard: React.FC<BriefingBoardProps> = ({
   planId,
-  title,
-  location,
   startDate,
   endDate,
   participants,
@@ -120,23 +118,8 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
     destinationCountry,
     userNationality,
   });
-  const ddayText = calculateDDayWithEnd(startDate, endDate);
-  const tripDurationText = formatTripNightsDays(startDate, endDate);
-
-  // D-Day 배지 색상 (투명도 포함)
-  const isEnded = ddayText.startsWith('여행 종료 ');
-  const isStartDay = ddayText === 'D-Day';
-  const isUpcoming = ddayText.startsWith('D-');
-  const isInProgress = ddayText.startsWith('D+') && !isEnded;
-  const ddayBadgeBgClass = isEnded
-    ? 'bg-gray-900'
-    : isStartDay
-      ? 'bg-blue-500/90'
-      : isUpcoming
-        ? 'bg-orange-500/90'
-        : isInProgress
-          ? 'bg-green-500/90'
-          : 'bg-gray-900';
+  // D-Day 관련 계산은 추후 배지 사용 시 활성화 예정
+  // const ddayText = calculateDDayWithEnd(startDate, endDate);
 
   // 최근 활동: 상위 컴포넌트에서 전달받은 데이터를 사용
 
@@ -158,7 +141,7 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
 
               {/* 참여자 아바타 목록 */}
               <div className='flex w-full flex-wrap items-center gap-2'>
-                {participants.map((participant, index) => (
+                {participants.map((participant) => (
                   <div key={participant.id} className='group relative'>
                     <div className='relative'>
                       <Avatar

--- a/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
+++ b/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
@@ -3,9 +3,7 @@
 import {
   IoAddOutline,
   IoCalendarOutline,
-  IoCheckmarkCircleOutline,
   IoDownloadOutline,
-  IoInformationCircleOutline,
   IoSettingsOutline,
   IoTimeOutline,
   IoWalletOutline,
@@ -20,7 +18,7 @@ import {
 } from '@ui/components';
 
 import { useBudgetWithExchange } from '@/hooks/useBudgetWithExchange';
-import { useReadinessScore } from '@/hooks/useReadinessScore';
+import { usePlanningProgress } from '@/hooks/usePlanningProgress';
 import { calculateDDayWithEnd, formatTripNightsDays } from '@/lib/travel-utils';
 
 import { SharedTodoWidget } from './SharedTodoWidget';
@@ -99,13 +97,12 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
   onBudgetClick,
   onReadinessClick,
 }) => {
-  // 실시간 준비율 계산
+  // 여행 계획율 계산
   const {
-    score: readinessScore,
-    status,
-    recommendations,
-    isLoading: readinessLoading,
-  } = useReadinessScore({
+    score: planningScore,
+    status: planningStatus,
+    isLoading: planningLoading,
+  } = usePlanningProgress({
     planId,
     startDate,
     endDate,
@@ -146,56 +143,6 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
   return (
     <div className='min-h-full w-full overflow-x-hidden bg-gray-50 px-1 py-3 sm:px-3 md:px-6 lg:px-8'>
       <div className='mx-auto w-full max-w-6xl space-y-4 sm:space-y-5 md:space-y-6'>
-        {/* 헤더 섹션 */}
-        <div className='w-full rounded-2xl bg-white p-3 shadow-sm sm:p-4 md:p-5 lg:p-6'>
-          <div className='flex w-full flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-0'>
-            <div className='min-w-0 flex-1 space-y-2'>
-              <Typography
-                variant='h4'
-                className='break-words text-lg font-bold text-gray-900 sm:text-xl md:text-2xl lg:text-3xl'
-              >
-                {title}
-              </Typography>
-              <div className='flex flex-col space-y-1 text-xs text-gray-600 sm:text-sm lg:flex-row lg:items-center lg:space-x-4 lg:space-y-0'>
-                <div className='flex items-center space-x-1'>
-                  <IoCalendarOutline className='h-3 w-3 sm:h-4 sm:w-4' />
-                  <span>
-                    {tripDurationText} {location}
-                  </span>
-                </div>
-                <div className='flex items-center space-x-1'>
-                  <IoTimeOutline className='h-3 w-3 sm:h-4 sm:w-4' />
-                  <span className='text-xs sm:text-sm'>
-                    {new Date(startDate).toLocaleDateString()} -{' '}
-                    {new Date(endDate).toLocaleDateString()}
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            {/* D-Day 카운터: 상태별 배지 색상 */}
-            <div
-              className={`w-full rounded-xl ${ddayBadgeBgClass} px-3 py-2 text-center text-white shadow-sm sm:w-auto sm:px-4 sm:py-3 sm:text-left md:px-5 md:py-4`}
-            >
-              <Typography
-                variant='h3'
-                className='text-lg font-bold sm:text-xl md:text-2xl lg:text-3xl'
-              >
-                {ddayText}
-              </Typography>
-              <Typography
-                variant='caption'
-                className='text-xs text-gray-300 sm:text-sm'
-              >
-                {!ddayText.includes('D+') && '여행까지 남은 시간'}
-              </Typography>
-            </div>
-          </div>
-
-          {/* 날씨 정보 */}
-          {/* Removed weather display */}
-        </div>
-
         {/* 실시간 현황과 핵심 요약 그리드 */}
         <div className='flex w-full flex-col gap-4 md:flex-row md:gap-5 lg:gap-6'>
           {/* 좌측 컬럼 - 사람과 활동 */}
@@ -368,7 +315,7 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
 
           {/* 우측 컬럼 - 진행상황 */}
           <div className='w-full min-w-0 flex-1 space-y-4 md:space-y-5 lg:space-y-6'>
-            {/* 여행 준비율 */}
+            {/* 여행 계획율 */}
             <div className='w-full rounded-xl bg-white p-3 shadow-sm sm:rounded-2xl sm:p-4 md:p-5 lg:p-6'>
               <div className='mb-4 flex items-center justify-between'>
                 <div className='flex items-center space-x-2'>
@@ -376,18 +323,18 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
                     variant='h6'
                     className='font-semibold text-gray-900'
                   >
-                    여행 준비율
+                    여행 계획율
                   </Typography>
-                  <span className='text-lg'>{status.emoji}</span>
+                  <span className='text-lg'>{planningStatus.emoji}</span>
                 </div>
-                {readinessLoading ? (
+                {planningLoading ? (
                   <div className='h-6 w-12 animate-pulse rounded bg-gray-200'></div>
                 ) : (
                   <Typography
                     variant='h6'
-                    className={`font-bold text-${status.color}-600`}
+                    className={`font-bold text-${planningStatus.color}-600`}
                   >
-                    {readinessScore}%
+                    {planningScore}%
                   </Typography>
                 )}
               </div>
@@ -395,38 +342,32 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
               <button
                 onClick={onReadinessClick}
                 className='w-full rounded-lg p-2 transition-all duration-200 sm:p-3'
-                disabled={!onReadinessClick || readinessLoading}
+                disabled={!onReadinessClick || planningLoading}
               >
                 <Progress
-                  value={readinessScore}
+                  value={planningScore}
                   size='medium'
-                  colorTheme={status.color as ProgressColorTheme}
+                  colorTheme={planningStatus.color as ProgressColorTheme}
                 />
               </button>
-
-              {/* 추천사항 */}
-              {recommendations.length > 0 && !readinessLoading && (
-                <div className='mt-4 rounded-lg bg-gray-50 p-3'>
-                  <div className='mb-2 flex items-center space-x-2'>
-                    <IoInformationCircleOutline className='h-4 w-4 text-blue-500' />
-                    <Typography
-                      variant='caption'
-                      className='font-medium text-gray-700'
-                    >
-                      추천사항
-                    </Typography>
-                  </div>
-                  <div className='space-y-1'>
-                    {recommendations.map((recommendation, index) => (
-                      <Typography
-                        key={index}
-                        variant='caption'
-                        className='block text-gray-600'
-                      >
-                        • {recommendation}
-                      </Typography>
-                    ))}
-                  </div>
+              {/* 한 줄 제안 (UX writing) */}
+              {!planningLoading && (
+                <div className='mt-3 rounded-lg bg-gray-50 p-3'>
+                  <Typography variant='caption' className='text-gray-700'>
+                    {planningScore <= 0 &&
+                      '시작해볼까요? 블록과 할 일을 추가하면 계획율이 올라가요.'}
+                    {planningScore > 0 &&
+                      planningScore < 30 &&
+                      '좋은 출발이에요. 오늘 1–2개만 더 추가해볼까요?'}
+                    {planningScore >= 30 &&
+                      planningScore < 70 &&
+                      '탄력 받았어요. 남은 일차에 핵심 활동을 채워봐요.'}
+                    {planningScore >= 70 &&
+                      planningScore < 90 &&
+                      '거의 다 됐어요. 이동/숙소만 확인하면 충분해요.'}
+                    {planningScore >= 90 &&
+                      '완벽에 가까워요. 세부만 다듬으면 끝!'}
+                  </Typography>
                 </div>
               )}
             </div>

--- a/apps/web/src/app/travel/[id]/components/DayTab.tsx
+++ b/apps/web/src/app/travel/[id]/components/DayTab.tsx
@@ -8,7 +8,7 @@ import { IoGridOutline } from 'react-icons/io5';
 import { Typography } from '@ui/components';
 
 import { useMobile } from '@/hooks';
-import { formatCurrency } from '@/lib/currency';
+import { CurrencyCode, formatCurrency } from '@/lib/currency';
 
 import { TabItem } from '../constants';
 
@@ -93,7 +93,7 @@ export const DayTab = forwardRef<HTMLButtonElement, DayTabProps>(
             <Typography variant='caption' className='text-xs text-gray-400'>
               {formatCurrency(
                 tab.totalCost.amount,
-                (tab.totalCost.currency || 'KRW') as any
+                (tab.totalCost.currency as CurrencyCode) || 'KRW'
               )}
             </Typography>
           ) : (

--- a/apps/web/src/app/travel/[id]/components/SharedTodoWidget.tsx
+++ b/apps/web/src/app/travel/[id]/components/SharedTodoWidget.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   IoAddOutline,
@@ -43,7 +43,7 @@ export const SharedTodoWidget: React.FC<SharedTodoWidgetProps> = ({
   const toast = useToast();
 
   // 투두리스트 조회
-  const fetchTodos = async () => {
+  const fetchTodos = useCallback(async () => {
     try {
       setIsLoading(true);
       const response = await fetch(`/api/todos?planId=${planId}`);
@@ -60,7 +60,7 @@ export const SharedTodoWidget: React.FC<SharedTodoWidgetProps> = ({
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [planId, toast]);
 
   // 새 투두 추가
   const handleAddTodo = async () => {
@@ -189,10 +189,10 @@ export const SharedTodoWidget: React.FC<SharedTodoWidgetProps> = ({
     }
   };
 
-  // 컴포넌트 마운트 시 투두리스트 조회
+  // 컴포넌트 마운트 및 planId 변경 시 투두리스트 조회
   useEffect(() => {
     fetchTodos();
-  }, [planId]);
+  }, [fetchTodos]);
 
   const pendingTodos = todos.filter((todo) => !todo.is_completed);
   const completedTodos = todos.filter((todo) => todo.is_completed);

--- a/apps/web/src/app/travel/[id]/components/TabContainer.tsx
+++ b/apps/web/src/app/travel/[id]/components/TabContainer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { IoChevronBackOutline, IoChevronForwardOutline } from 'react-icons/io5';
 
-import { useMobile } from '@/hooks';
+// import { useMobile } from '@/hooks';
 
 import { TabItem } from '../constants';
 import { DayTab } from './DayTab';
@@ -22,7 +22,7 @@ export const TabContainer: React.FC<TabContainerProps> = ({
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const selectedTabRef = useRef<HTMLButtonElement>(null);
-  const isMobile = useMobile();
+  // const isMobile = useMobile();
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 

--- a/apps/web/src/app/travel/[id]/view.tsx
+++ b/apps/web/src/app/travel/[id]/view.tsx
@@ -18,18 +18,18 @@ import { useSession } from '@/hooks/useSession';
 import { useToast } from '@/hooks/useToast';
 import { useTravelDetail } from '@/hooks/useTravelDetail';
 import { useTravelRealtime } from '@/hooks/useTravelRealtime';
+import type {
+  ActivityItem as ApiActivityItem,
+  TravelBlock as ApiBlock,
+  Participant as ApiParticipant,
+} from '@/lib/api/travel';
 import { calculateDDayWithEnd } from '@/lib/travel-utils';
 import { TravelBlock } from '@/types/travel/blocks';
 
 import { BriefingBoard, TabContainer, TravelHeader } from './components';
 import { TabItem, TRAVEL_DETAIL_CONSTANTS } from './constants';
 
-// 임시로 확장된 타입 정의 (DB 필드 추가 반영)
-interface ExtendedTravelPlanDetail {
-  target_budget?: number;
-  budget_currency?: string;
-  destination_country?: string;
-}
+// 임시로 확장된 타입 정의 제거
 
 const TravelDetailView = () => {
   const params = useParams();
@@ -41,24 +41,22 @@ const TravelDetailView = () => {
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [selectedBlock, setSelectedBlock] = useState<TravelBlock | null>(null);
   const [selectedDay, setSelectedDay] = useState<number>(0); // 0은 대시보드
-  const [showInviteModal, setShowInviteModal] = useState(false);
-  const [showExportModal, setShowExportModal] = useState(false);
-  const [showSettingsModal, setShowSettingsModal] = useState(false);
 
   const planId = params.id as string;
 
   // 새로운 API 훅 사용
-  const {
-    data: travelData,
-    isLoading,
-    error,
-    refetch,
-  } = useTravelDetail(planId);
+  const { data: travelData, isLoading, error } = useTravelDetail(planId);
 
   const travelPlan = travelData?.travelPlan;
-  const participants = travelData?.participants || [];
-  const blocks = travelData?.blocks || [];
-  const activities = travelData?.activities || [];
+  const participants = useMemo(
+    () => travelData?.participants ?? [],
+    [travelData?.participants]
+  );
+  const blocks = useMemo(() => travelData?.blocks ?? [], [travelData?.blocks]);
+  const activities = useMemo(
+    () => travelData?.activities ?? [],
+    [travelData?.activities]
+  );
 
   // 실시간 기능 활성화 (항상 호출)
   useTravelRealtime(planId);
@@ -72,22 +70,13 @@ const TravelDetailView = () => {
   });
 
   // 블록 시스템 Hook (항상 호출)
-  const {
-    timeline,
-    isLoading: blocksLoading,
-    createBlock,
-    moveBlock,
-    deleteBlock,
-    isCreating,
-    isMoving,
-    isDeleting,
-    handleBlockEvent,
-  } = useBlocks({
-    planId,
-    startDate: travelPlan?.start_date || '',
-    endDate: travelPlan?.end_date || '',
-    planLocation: travelPlan?.location || '',
-  });
+  const { timeline, createBlock, moveBlock, deleteBlock, isCreating } =
+    useBlocks({
+      planId,
+      startDate: travelPlan?.start_date || '',
+      endDate: travelPlan?.end_date || '',
+      planLocation: travelPlan?.location || '',
+    });
 
   // 탭 데이터 생성
   const tabs = useMemo((): TabItem[] => {
@@ -117,62 +106,19 @@ const TravelDetailView = () => {
       hasShownErrorRef.current = true;
       toast.error('여행 정보를 불러오는데 실패했습니다.');
     }
-  }, [error]);
-
-  // 총 예산 계산
-  const totalBudget = useMemo(() => {
-    return blocks.reduce((total: number, block: any) => {
-      if (block.cost && typeof block.cost === 'object' && block.cost !== null) {
-        const costObj = block.cost as { amount?: number };
-        if (typeof costObj.amount === 'number') {
-          return total + costObj.amount;
-        }
-      }
-      return total;
-    }, 0);
-  }, [blocks]);
-
-  // 준비도 점수 계산
-  const readinessScore = useMemo(() => {
-    if (!travelPlan) return 0;
-
-    const totalDays =
-      Math.ceil(
-        (new Date(travelPlan.end_date).getTime() -
-          new Date(travelPlan.start_date).getTime()) /
-          (1000 * 60 * 60 * 24)
-      ) + 1;
-
-    const blocksPerDay = blocks.length / totalDays;
-    const participantsCount = participants.length;
-
-    // 간단한 준비도 계산 (블록 수, 참여자 수 기반)
-    let score = 0;
-    if (blocksPerDay >= 2) score += 30;
-    else if (blocksPerDay >= 1) score += 20;
-    else score += 10;
-
-    if (participantsCount >= 3) score += 30;
-    else if (participantsCount >= 2) score += 20;
-    else score += 10;
-
-    // 최근 활동이 있으면 추가 점수
-    if (activities.length > 0) score += 20;
-
-    return Math.min(score, 100);
-  }, [travelPlan, blocks, participants, activities]);
+  }, [error, toast]);
 
   // 핫 토픽 계산 (댓글이 많은 블록들)
   const hotTopics = useMemo(() => {
     // 실제로는 댓글 수를 API에서 가져와야 함
     // 현재는 임시로 최근 활동에서 블록 관련 활동을 찾아서 반환
-    const blockActivities = activities.filter(
-      (activity: any) => activity.blockId
+    const blockActivities = (activities as ApiActivityItem[]).filter(
+      (activity) => !!activity.blockId
     );
 
     // 블록별 활동 수 계산
     const blockActivityCounts = blockActivities.reduce(
-      (acc: Record<string, number>, activity: any) => {
+      (acc: Record<string, number>, activity) => {
         const blockId = activity.blockId!;
         acc[blockId] = (acc[blockId] || 0) + 1;
         return acc;
@@ -187,7 +133,8 @@ const TravelDetailView = () => {
       .map(([blockId]) => ({
         id: blockId,
         title:
-          blocks.find((b: any) => b.id === blockId)?.title || '알 수 없는 블록',
+          (blocks as ApiBlock[]).find((b) => b.id === blockId)?.title ||
+          '알 수 없는 블록',
         commentCount: blockActivityCounts[blockId] || 0,
         blockId: blockId,
       }));
@@ -219,15 +166,15 @@ const TravelDetailView = () => {
   }
 
   const handleInviteParticipants = () => {
-    setShowInviteModal(true);
+    toast('동반자 초대 기능은 준비 중입니다.');
   };
 
   const handleExport = () => {
-    setShowExportModal(true);
+    toast('내보내기 기능은 준비 중입니다.');
   };
 
   const handleSettings = () => {
-    setShowSettingsModal(true);
+    toast('설정 기능은 준비 중입니다.');
   };
 
   const handleBudgetClick = () => {
@@ -293,16 +240,31 @@ const TravelDetailView = () => {
                 location={travelPlan.location}
                 startDate={travelPlan.start_date}
                 endDate={travelPlan.end_date}
-                participants={participants.map((p: any) => ({
+                participants={(participants as ApiParticipant[]).map((p) => ({
                   id: p.id,
                   nickname: p.nickname || '알 수 없음',
                   profile_image_url: p.profile_image_url,
                   isOnline: p.isOnline || false,
                 }))}
                 activities={activities}
-                totalBudget={(travelPlan as any).target_budget || 0}
-                currency={(travelPlan as any).budget_currency || 'KRW'}
-                destinationCountry={(travelPlan as any).destination_country}
+                totalBudget={
+                  (travelPlan as unknown as Partial<{ target_budget: number }>)
+                    ?.target_budget || 0
+                }
+                currency={
+                  (
+                    travelPlan as unknown as Partial<{
+                      budget_currency: string;
+                    }>
+                  )?.budget_currency || 'KRW'
+                }
+                destinationCountry={
+                  (
+                    travelPlan as unknown as Partial<{
+                      destination_country: string;
+                    }>
+                  )?.destination_country
+                }
                 userNationality={userProfile?.nationality}
                 hotTopics={hotTopics}
                 onInviteParticipants={handleInviteParticipants}

--- a/apps/web/src/app/travel/[id]/view.tsx
+++ b/apps/web/src/app/travel/[id]/view.tsx
@@ -18,6 +18,7 @@ import { useSession } from '@/hooks/useSession';
 import { useToast } from '@/hooks/useToast';
 import { useTravelDetail } from '@/hooks/useTravelDetail';
 import { useTravelRealtime } from '@/hooks/useTravelRealtime';
+import { calculateDDayWithEnd } from '@/lib/travel-utils';
 import { TravelBlock } from '@/types/travel/blocks';
 
 import { BriefingBoard, TabContainer, TravelHeader } from './components';
@@ -254,51 +255,9 @@ const TravelDetailView = () => {
     setShowDetailModal(true);
   };
 
-  // D-Day 계산
-  const getDDay = () => {
-    if (!travelPlan) return '';
-
-    const startDateObj = new Date(travelPlan.start_date);
-    const endDateObj = new Date(travelPlan.end_date);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    startDateObj.setHours(0, 0, 0, 0);
-    endDateObj.setHours(0, 0, 0, 0);
-
-    const diffTime = startDateObj.getTime() - today.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-    // 여행 시작 전
-    if (diffDays > 0) return `D-${diffDays}`;
-
-    // 여행 시작일
-    if (diffDays === 0) return 'D-Day';
-
-    // 여행 중
-    if (today >= startDateObj && today <= endDateObj) {
-      const daysSinceStart = Math.ceil(
-        (today.getTime() - startDateObj.getTime()) / (1000 * 60 * 60 * 24)
-      );
-      return `D+${daysSinceStart}`;
-    }
-
-    // 여행 종료 후
-    const daysSinceEnd = Math.ceil(
-      (today.getTime() - endDateObj.getTime()) / (1000 * 60 * 60 * 24)
-    );
-    return `여행 종료 ${daysSinceEnd}일`;
-  };
-
-  // 여행 기간 계산
-  const getTripDuration = () => {
-    if (!travelPlan) return '';
-
-    const start = new Date(travelPlan.start_date);
-    const end = new Date(travelPlan.end_date);
-    const diffTime = end.getTime() - start.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
-    return `${diffDays - 1}박 ${diffDays}일`;
-  };
+  const ddayText = travelPlan
+    ? calculateDDayWithEnd(travelPlan.start_date, travelPlan.end_date)
+    : '';
 
   // 편집 권한 확인 (임시로 true, 나중에 실제 권한 체크 로직으로 교체)
   const canEdit = true;
@@ -314,7 +273,7 @@ const TravelDetailView = () => {
           startDate={travelPlan.start_date}
           endDate={travelPlan.end_date}
           participantsCount={participants.length}
-          dDay={getDDay()}
+          dDay={ddayText}
         />
 
         {/* 탭 컨테이너 */}

--- a/apps/web/src/components/common/NewTravelModal.tsx
+++ b/apps/web/src/components/common/NewTravelModal.tsx
@@ -2,8 +2,6 @@
 
 import React, { useState } from 'react';
 
-import { useRouter } from 'next/navigation';
-
 import { FaPencilAlt, FaRobot } from 'react-icons/fa';
 
 import { Icon, Typography } from '@ui/components';
@@ -20,7 +18,6 @@ export const NewTravelModal: React.FC<NewTravelModalProps> = ({
   isOpen,
   onClose,
 }) => {
-  const router = useRouter();
   const [showBasicInfoModal, setShowBasicInfoModal] = useState(false);
 
   const handleDirectPlanning = () => {

--- a/apps/web/src/components/travel/detail/BlockCreateModal.tsx
+++ b/apps/web/src/components/travel/detail/BlockCreateModal.tsx
@@ -128,7 +128,7 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
     if (!title.trim()) return;
 
     // 블록 타입별 메타데이터 구성
-    const meta: any = {};
+    const meta: Record<string, unknown> = {};
 
     switch (selectedType) {
       case 'flight':
@@ -564,7 +564,7 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
                   type='text'
                   value={amount}
                   onChange={(e) =>
-                    setAmount(formatCurrencyInput(e.target.value, currency))
+                    setAmount(formatCurrencyInput(e.target.value))
                   }
                   placeholder='0'
                   className='w-full rounded-xl border border-gray-300 py-3 pl-10 pr-4 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'

--- a/apps/web/src/components/travel/detail/TravelTimelineCanvas.tsx
+++ b/apps/web/src/components/travel/detail/TravelTimelineCanvas.tsx
@@ -11,7 +11,6 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import {
-  arrayMove,
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
@@ -25,7 +24,7 @@ import {
   IoRestaurantOutline,
 } from 'react-icons/io5';
 
-import { Button, Typography } from '@ui/components';
+import { Typography } from '@ui/components';
 
 import { BlockType, TravelBlock, TravelTimeline } from '@/types/travel/blocks';
 
@@ -35,8 +34,8 @@ interface TravelTimelineCanvasProps {
   timeline: TravelTimeline;
   canEdit: boolean;
   selectedDay: number;
-  onDaySelect: (dayNumber: number) => void;
-  onBlockCreate: (dayNumber: number) => void;
+  onDaySelect: (_dayNumber: number) => void;
+  onBlockCreate: (_dayNumber: number) => void;
   onBlockMove?: (
     blockId: string,
     newDayNumber: number,
@@ -62,8 +61,8 @@ export const TravelTimelineCanvas: React.FC<TravelTimelineCanvasProps> = ({
   timeline,
   canEdit,
   selectedDay,
-  onDaySelect,
-  onBlockCreate,
+  onDaySelect: _onDaySelect,
+  onBlockCreate: _onBlockCreate,
   onBlockMove,
   onBlockClick,
 }) => {
@@ -135,20 +134,9 @@ export const TravelTimelineCanvas: React.FC<TravelTimelineCanvasProps> = ({
 
     if (droppedBlock) {
       // 같은 날짜 내에서 순서 변경
-      const oldIndex = selectedDayData.blocks.findIndex(
-        (block) => block.id === activeId
-      );
       const newIndex = selectedDayData.blocks.findIndex(
         (block) => block.id === overId
       );
-
-      // arrayMove를 사용하여 새로운 순서 계산
-      const reorderedBlocks = arrayMove(
-        selectedDayData.blocks,
-        oldIndex,
-        newIndex
-      );
-      const movedBlock = reorderedBlocks[newIndex];
 
       // 블록 이동 실행
       if (onBlockMove) {

--- a/apps/web/src/components/travel/modals/TravelBasicInfoModal.tsx
+++ b/apps/web/src/components/travel/modals/TravelBasicInfoModal.tsx
@@ -4,15 +4,10 @@ import React, { useEffect, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import {
-  IoCopyOutline,
-  IoLinkOutline,
-  IoPersonOutline,
-  IoWalletOutline,
-} from 'react-icons/io5';
+import { IoPersonOutline, IoWalletOutline } from 'react-icons/io5';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Button, Input, Switch, Typography } from '@ui/components';
+import { Button, Input, Typography } from '@ui/components';
 
 import { Modal } from '@/components/basic';
 import { countriesISO } from '@/components/travel/constants/countries';
@@ -258,7 +253,7 @@ const TravelBasicInfoModal: React.FC<TravelBasicInfoModalProps> = ({
       toast.success('여행 계획이 생성되었습니다!');
       onClose();
       router.push('/');
-    } catch (error) {
+    } catch {
       toast.error('여행 계획 생성 중 오류가 발생했습니다.');
     } finally {
       setLoading(false);

--- a/apps/web/src/components/travel/overview/TravelPlansList.tsx
+++ b/apps/web/src/components/travel/overview/TravelPlansList.tsx
@@ -17,7 +17,6 @@ import { Button, Input, Typography } from '@ui/components';
 import TravelBasicInfoModal from '@/components/travel/modals/TravelBasicInfoModal';
 import { useSession } from '@/hooks/useSession';
 import { createClient } from '@/lib/supabase/client/supabase';
-import { formatDateRange } from '@/lib/travel-utils';
 
 interface TravelPlan {
   id: string;
@@ -127,6 +126,17 @@ const TravelPlansList: React.FC = () => {
   useEffect(() => {
     fetchTravelPlans();
   }, [fetchTravelPlans]);
+
+  // 로그인 직후 또는 토큰이 갱신되면 즉시 목록을 다시 가져온다
+  useEffect(() => {
+    const { data } = supabase.auth.onAuthStateChange(() => {
+      // userProfile 설정 이후에도 안전하게 재조회
+      fetchTravelPlans();
+    });
+    return () => {
+      data.subscription.unsubscribe();
+    };
+  }, [supabase, fetchTravelPlans]);
 
   const sortedPlans = useMemo(
     () => sortPlans(travelPlans, sort),
@@ -251,7 +261,7 @@ const TravelPlansList: React.FC = () => {
               <select
                 value={sort}
                 onChange={(e) => handleSortChange(e.target.value as SortType)}
-                className='appearance-none rounded-lg border border-gray-300 bg-white px-3 py-2 pr-8 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500'
+                className='appearance-none rounded-lg border border-gray-300 bg-white px-3 py-3 pr-8 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500'
               >
                 {sortOptions.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/apps/web/src/hooks/useBlocks.ts
+++ b/apps/web/src/hooks/useBlocks.ts
@@ -137,7 +137,10 @@ export const useBlocks = ({
     enabled: !!planId,
     retry: 1,
     retryDelay: 1000,
-    staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
+    // 최신 데이터 보장을 위해 재진입 시 항상 리패치
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: 'always',
+    staleTime: 0,
   });
 
   // 날짜별로 그룹화된 블록 계산 (타임라인 구성)

--- a/apps/web/src/hooks/useBudgetWithExchange.ts
+++ b/apps/web/src/hooks/useBudgetWithExchange.ts
@@ -241,7 +241,7 @@ export const useBudgetWithExchange = ({
         },
       };
     }
-  }, [planId]);
+  }, [planId, budgetCurrency, getUserCurrency, getDestinationCurrency]);
 
   // 예산 정보 계산 및 변환
   const calculateBudgetInfo = useCallback(async () => {
@@ -375,7 +375,6 @@ export const useBudgetWithExchange = ({
   }, [
     targetBudget,
     budgetCurrency,
-    planId,
     getUserCurrency,
     getDestinationCurrency,
     calculateSpentAmount,

--- a/apps/web/src/hooks/useGoogleAnalytics.ts
+++ b/apps/web/src/hooks/useGoogleAnalytics.ts
@@ -9,7 +9,7 @@ declare global {
     gtag: (
       command: 'config' | 'event',
       targetId: string,
-      config?: Record<string, any>
+      config?: Record<string, unknown>
     ) => void;
   }
 }

--- a/apps/web/src/hooks/usePlanningProgress.ts
+++ b/apps/web/src/hooks/usePlanningProgress.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  calculatePlanningScore,
+  getPlanningStatus,
+} from '@/lib/planning-calculator';
+
+type BlockLite = { id: string; block_type?: string };
+type TodoLite = { id: string };
+
+interface UsePlanningProgressProps {
+  planId: string;
+  startDate: string;
+  endDate: string;
+}
+
+export const usePlanningProgress = ({
+  planId,
+  startDate,
+  endDate,
+}: UsePlanningProgressProps) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [blocksCount, setBlocksCount] = useState(0);
+  const [todosCount, setTodosCount] = useState(0);
+  const [score, setScore] = useState(0);
+
+  const getTripDays = useCallback(() => {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    const diffTime = end.getTime() - start.getTime();
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
+  }, [startDate, endDate]);
+
+  const fetchCounts = useCallback(async () => {
+    if (!planId) return;
+    try {
+      const [blocksRes, todosRes] = await Promise.all([
+        fetch(`/api/blocks?planId=${planId}`),
+        fetch(`/api/todos?planId=${planId}`),
+      ]);
+      if (blocksRes.ok) {
+        const json = await blocksRes.json();
+        const blocks = (json?.blocks as BlockLite[] | undefined) || [];
+        const counted = blocks.filter(
+          (b) => (b?.block_type || '').toLowerCase() !== 'memo'
+        ).length;
+        setBlocksCount(counted);
+      }
+      if (todosRes.ok) {
+        const json = await todosRes.json();
+        setTodosCount((json?.todos as TodoLite[] | undefined)?.length || 0);
+      }
+    } catch (e) {
+      // ignore
+    }
+  }, [planId]);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    await fetchCounts();
+    setIsLoading(false);
+  }, [fetchCounts]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (isLoading) return;
+    const days = getTripDays();
+    const s = calculatePlanningScore(blocksCount, todosCount, days);
+    setScore(s);
+  }, [isLoading, blocksCount, todosCount, getTripDays]);
+
+  const status = getPlanningStatus(score);
+
+  return { score, status, isLoading, refresh };
+};

--- a/apps/web/src/hooks/usePlanningProgress.ts
+++ b/apps/web/src/hooks/usePlanningProgress.ts
@@ -50,7 +50,7 @@ export const usePlanningProgress = ({
         const json = await todosRes.json();
         setTodosCount((json?.todos as TodoLite[] | undefined)?.length || 0);
       }
-    } catch (e) {
+    } catch {
       // ignore
     }
   }, [planId]);

--- a/apps/web/src/hooks/useToast.ts
+++ b/apps/web/src/hooks/useToast.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 
 import { ToastType } from '@/components/basic/Toast/Toast';
 import { ToastContext } from '@/providers/toast-provider';
@@ -12,34 +12,33 @@ export const useToast = () => {
     throw new Error('useToast must be used within a ToastProvider');
   }
 
-  const toast = (
-    message: string,
-    options?: { type?: ToastType; title?: string; duration?: number }
-  ) => {
-    return context.showToast({ message, ...options });
-  };
+  // toast 메모이제이션 처리
+  const toast = useMemo(() => {
+    const base = (
+      message: string,
+      options?: { type?: ToastType; title?: string; duration?: number }
+    ) => context.showToast({ message, ...options });
 
-  toast.success = (
-    message: string,
-    options?: { title?: string; duration?: number }
-  ) => {
-    return context.showToast({ message, type: 'success', ...options });
-  };
+    base.success = (
+      message: string,
+      options?: { title?: string; duration?: number }
+    ) => context.showToast({ message, type: 'success', ...options });
 
-  toast.error = (
-    message: string,
-    options?: { title?: string; duration?: number }
-  ) => {
-    return context.showToast({ message, type: 'error', ...options });
-  };
+    base.error = (
+      message: string,
+      options?: { title?: string; duration?: number }
+    ) => context.showToast({ message, type: 'error', ...options });
 
-  toast.hide = (id: string) => {
-    context.hideToast(id);
-  };
+    base.hide = (id: string) => {
+      context.hideToast(id);
+    };
 
-  toast.hideAll = () => {
-    context.hideAllToasts();
-  };
+    base.hideAll = () => {
+      context.hideAllToasts();
+    };
+
+    return base;
+  }, [context]);
 
   return toast;
 };

--- a/apps/web/src/hooks/useTravelDetail.ts
+++ b/apps/web/src/hooks/useTravelDetail.ts
@@ -2,7 +2,6 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   createBlock,
-  type CreateBlockRequest,
   deleteBlock,
   fetchTravelDetail,
   moveBlock,
@@ -81,7 +80,7 @@ export function useUpdateBlock() {
       blockId: string;
       data: UpdateBlockRequest;
     }) => updateBlock(blockId, data),
-    onSuccess: (updatedBlock, variables) => {
+    onSuccess: (updatedBlock) => {
       // 여행 상세 정보 캐시 업데이트
       queryClient.setQueryData<TravelDetailResponse>(
         ['travel-detail', updatedBlock.plan_id],
@@ -131,7 +130,7 @@ export function useMoveBlock() {
       blockId: string;
       data: MoveBlockRequest;
     }) => moveBlock(blockId, data),
-    onSuccess: (_, variables) => {
+    onSuccess: (_) => {
       // 블록 이동 후 전체 데이터를 다시 가져옴 (순서가 복잡하게 변경되므로)
       // 실제로는 낙관적 업데이트를 구현할 수 있지만, 복잡성을 줄이기 위해 무효화
       queryClient.invalidateQueries({ queryKey: ['travel-detail'] });

--- a/apps/web/src/hooks/useTravelPlans.ts
+++ b/apps/web/src/hooks/useTravelPlans.ts
@@ -194,7 +194,7 @@ export const useRecentActivities = (limit: number = 10) => {
               user_id: activity.user_id,
               action_type: activity.type, // type을 action_type으로 매핑
               description: activity.content, // content를 description으로 매핑
-              metadata: null, // metadata 컬럼이 없으므로 null
+              metadata: undefined, // metadata 컬럼이 없으므로 undefined로 정규화
               created_at: activity.created_at,
               updated_at: activity.created_at, // updated_at 컬럼이 없으므로 created_at 사용
               user: userProfile || {

--- a/apps/web/src/hooks/useTravelRealtime.ts
+++ b/apps/web/src/hooks/useTravelRealtime.ts
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 
+import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
 import { useQueryClient } from '@tanstack/react-query';
 
+import type {
+  ActivityItem as ApiActivityItem,
+  TravelDetailResponse,
+} from '@/lib/api/travel';
 import { createClient } from '@/lib/supabase/client/supabase';
 
 export function useTravelRealtime(planId: string) {
@@ -23,7 +28,7 @@ export function useTravelRealtime(planId: string) {
           table: 'travel_blocks',
           filter: `plan_id=eq.${planId}`,
         },
-        (payload) => {
+        (_payload) => {
           // 캐시 무효화하여 최신 데이터 가져오기
           queryClient.invalidateQueries({
             queryKey: ['travel-detail', planId],
@@ -38,30 +43,64 @@ export function useTravelRealtime(planId: string) {
           table: 'travel_activities',
           filter: `plan_id=eq.${planId}`,
         },
-        (payload) => {
+        (
+          payload: RealtimePostgresChangesPayload<{
+            id: string;
+            plan_id: string;
+            user_id: string;
+            block_id?: string | null;
+            type?: string | null;
+            activity_type?: string | null;
+            content?: string | null;
+            description?: string | null;
+            created_at: string;
+          }>
+        ) => {
           // 활동 로그가 추가되면 캐시 업데이트
           if (payload.eventType === 'INSERT') {
-            queryClient.setQueryData(
+            queryClient.setQueryData<TravelDetailResponse>(
               ['travel-detail', planId],
-              (oldData: any) => {
+              (oldData) => {
                 if (!oldData) return oldData;
 
                 // 새로운 활동을 맨 앞에 추가 (내용 비어있을 때 가독성 있는 문구 생성)
                 const participant = oldData.participants.find(
-                  (p: any) => p.user_id === payload.new.user_id
+                  (p) => p.user_id === payload.new.user_id
                 );
                 const relatedBlock = oldData.blocks.find(
-                  (b: any) => b.id === payload.new.block_id
+                  (b) => b.id === payload.new.block_id
                 );
 
-                const inferredType =
-                  (payload.new as any).type ||
-                  (payload.new as any).activity_type;
+                const rawType =
+                  payload.new.type || payload.new.activity_type || undefined;
+                const mapActivityType = (
+                  t?: string | null
+                ): ApiActivityItem['type'] => {
+                  switch (t) {
+                    case 'block_created':
+                    case 'block_add':
+                      return 'block_add';
+                    case 'block_updated':
+                    case 'block_edit':
+                      return 'block_edit';
+                    case 'block_deleted':
+                    case 'block_delete':
+                      return 'block_delete';
+                    case 'block_move':
+                      return 'block_move';
+                    case 'participant_join':
+                    case 'participant_added':
+                      return 'participant_join';
+                    case 'comment':
+                    default:
+                      return 'comment';
+                  }
+                };
+                const inferredType = mapActivityType(rawType);
                 const inferredContent =
-                  (payload.new as any).content ||
-                  (payload.new as any).description;
+                  payload.new.content || payload.new.description || undefined;
 
-                const newActivity = {
+                const newActivity: ApiActivityItem = {
                   id: payload.new.id,
                   type: inferredType,
                   user: {
@@ -75,30 +114,30 @@ export function useTravelRealtime(planId: string) {
                       const name = participant?.nickname || '사용자';
                       const title = relatedBlock?.title || '블록';
                       switch (inferredType) {
-                        case 'block_created':
+                        case 'block_add':
                           return `${name}님이 "${title}"을 추가했습니다`;
-                        case 'block_updated':
+                        case 'block_edit':
                           return `${name}님이 "${title}"을 수정했습니다`;
                         case 'block_move':
                           return `${name}님이 "${title}"을 이동했습니다`;
-                        case 'block_deleted':
+                        case 'block_delete':
                           return `${name}님이 블록을 삭제했습니다`;
-                        case 'comment':
-                          return `${name}님이 댓글을 남겼습니다`;
-                        case 'participant_added':
+                        case 'participant_join':
                           return `${name}님이 참여했습니다`;
-                        case 'participant_removed':
-                          return `${name}님이 나갔습니다`;
+                        case 'comment':
                         default:
                           return '활동이 기록되었습니다';
                       }
                     })(),
                   timestamp: payload.new.created_at,
-                  blockId: payload.new.block_id,
+                  blockId: payload.new.block_id ?? undefined,
                   blockTitle: relatedBlock?.title,
                 };
 
-                const nextActivities = [newActivity, ...oldData.activities];
+                const nextActivities = [
+                  newActivity,
+                  ...(oldData.activities || []),
+                ];
                 // 최대 5개 유지
                 const trimmed = nextActivities.slice(0, 5);
                 return {
@@ -118,7 +157,7 @@ export function useTravelRealtime(planId: string) {
           table: 'travel_plan_participants',
           filter: `plan_id=eq.${planId}`,
         },
-        (payload) => {
+        (_payload) => {
           // 참여자 변경 시 캐시 무효화
           queryClient.invalidateQueries({
             queryKey: ['travel-detail', planId],

--- a/apps/web/src/lib/api/travel.ts
+++ b/apps/web/src/lib/api/travel.ts
@@ -1,5 +1,3 @@
-import { createClient } from '@/lib/supabase/client/supabase';
-
 export interface TravelPlanDetail {
   id: string;
   title: string;

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -173,6 +173,8 @@ export function formatCurrency(amount: number, currency: CurrencyCode): string {
       maximumFractionDigits: currencyInfo.decimals,
     }).format(amount);
   } catch (error) {
+    console.error(error);
+
     // Fallback: 심볼 + 숫자 (Intl.NumberFormat 실패 시)
     const formattedNumber = amount.toLocaleString('ko-KR', {
       minimumFractionDigits: currencyInfo.decimals,
@@ -189,15 +191,11 @@ export function formatCurrency(amount: number, currency: CurrencyCode): string {
  * @param currency - 통화 코드
  * @returns 포맷팅된 입력값
  */
-export function formatCurrencyInput(
-  value: string,
-  currency: CurrencyCode
-): string {
+export function formatCurrencyInput(value: string): string {
   // 숫자가 아닌 문자 제거
   const numbers = value.replace(/[^0-9]/g, '');
   if (!numbers) return '';
 
-  const currencyInfo = CURRENCIES[currency];
   const amount = parseInt(numbers);
 
   // 천 단위 구분자 추가

--- a/apps/web/src/lib/exchange-rate.ts
+++ b/apps/web/src/lib/exchange-rate.ts
@@ -12,21 +12,6 @@ interface ExchangeRateResponse {
   rates: Record<string, number>;
 }
 
-interface ConversionResponse {
-  success: boolean;
-  query: {
-    from: string;
-    to: string;
-    amount: number;
-  };
-  info: {
-    timestamp: number;
-    rate: number;
-  };
-  date: string;
-  result: number;
-}
-
 // 환율 캐시 (1시간 유효)
 const exchangeRateCache = new Map<
   string,

--- a/apps/web/src/lib/planning-calculator.ts
+++ b/apps/web/src/lib/planning-calculator.ts
@@ -1,0 +1,83 @@
+export type PlanningColor = 'red' | 'orange' | 'blue' | 'green';
+
+export interface PlanningConfig {
+  blocksPerDayTarget?: number; // 기본 2.2 (완만화)
+  todosPerDayTarget?: number; // 기본 0.8 (완만화)
+  blockWeight?: number; // 기본 0.85 (블록 비중 상향)
+  todoWeight?: number; // 기본 0.15
+}
+
+export function calculatePlanningScore(
+  blocksCount: number,
+  todosCount: number,
+  tripDays: number,
+  config?: PlanningConfig
+): number {
+  const {
+    blocksPerDayTarget = 2.2,
+    todosPerDayTarget = 0.8,
+    blockWeight = 0.85,
+    todoWeight = 0.15,
+  } = config || {};
+
+  const safeDays = Math.max(1, Math.floor(tripDays) || 1);
+  const blockTarget = safeDays * blocksPerDayTarget;
+  const todoTarget = safeDays * todosPerDayTarget;
+
+  // 1) 블록: 일차 커버리지(블록이 존재하는 날짜 비율)와 개수 비율을 결합
+  const coveredDays = Math.min(blocksCount || 0, safeDays);
+  const coverageRatio = coveredDays / safeDays; // 0~1
+  const blockCountRatio = Math.min(
+    1,
+    (blocksCount || 0) / Math.max(1, blockTarget)
+  );
+  const blockRatio = 0.6 * coverageRatio + 0.4 * blockCountRatio; // 커버리지를 더 중요하게
+
+  // 2) 투두: 체감효과(sqrt) 적용해 완만하게
+  const todoLinear = Math.min(1, (todosCount || 0) / Math.max(1, todoTarget));
+  const todoRatio = Math.sqrt(todoLinear);
+
+  const raw = blockWeight * blockRatio + todoWeight * todoRatio;
+  const score = Math.round(Math.min(1, Math.max(0, raw)) * 100);
+  return score;
+}
+
+export function getPlanningStatus(score: number): {
+  message: string;
+  color: PlanningColor;
+  emoji: string;
+} {
+  if (score <= 0) {
+    return {
+      message: '시작해볼까요? 블록과 할 일을 추가하면 계획율이 올라가요.',
+      color: 'red',
+      emoji: '🌱',
+    };
+  }
+  if (score < 30) {
+    return {
+      message: '좋은 출발이에요. 오늘 1–2개만 더 추가해볼까요?',
+      color: 'red',
+      emoji: '🚀',
+    };
+  }
+  if (score < 70) {
+    return {
+      message: '탄력 받았어요. 남은 일차에 핵심 활동을 채워봐요.',
+      color: 'orange',
+      emoji: '💪',
+    };
+  }
+  if (score < 90) {
+    return {
+      message: '거의 다 됐어요. 이동/숙소만 확인하면 충분해요.',
+      color: 'blue',
+      emoji: '✨',
+    };
+  }
+  return {
+    message: '완벽에 가까워요. 세부만 다듬으면 끝!',
+    color: 'green',
+    emoji: '🎉',
+  };
+}

--- a/apps/web/src/lib/readiness-calculator.ts
+++ b/apps/web/src/lib/readiness-calculator.ts
@@ -8,7 +8,7 @@ interface Block {
   title?: string;
   // 과거 간이 스키마 호환
   time?: string;
-  location?: any;
+  location?: string | { address?: string } | null;
   description?: string;
   block_type: string;
   time_range?: { start_time?: string; end_time?: string };

--- a/apps/web/src/lib/socket/socket-client.ts
+++ b/apps/web/src/lib/socket/socket-client.ts
@@ -7,8 +7,41 @@ import { BlockEvent } from '@/types/travel/blocks';
  * 실시간 협업 기능을 위한 웹소켓 연결을 담당
  * 싱글톤 패턴으로 구현하여 앱 전체에서 하나의 연결만 유지
  */
+type ServerToClientEvents = {
+  block_event: (event: BlockEvent) => void;
+  cursor_move: (data: {
+    userId: string;
+    x: number;
+    y: number;
+    userName: string;
+  }) => void;
+  participant_status_change: (data: {
+    userId: string;
+    status: 'online' | 'offline';
+    userName: string;
+  }) => void;
+};
+
+type ClientToServerEvents = {
+  join_travel_plan: (planId: string) => void;
+  leave_travel_plan: (planId: string) => void;
+  block_event: (data: {
+    planId: string;
+    event: BlockEvent;
+    timestamp: string;
+  }) => void;
+  cursor_move: (data: {
+    planId: string;
+    x: number;
+    y: number;
+    userName: string;
+    timestamp: number;
+  }) => void;
+};
+
 class SocketManager {
-  private socket: Socket | null = null;
+  private socket: Socket<ServerToClientEvents, ClientToServerEvents> | null =
+    null;
   private currentTravelPlanId: string | null = null;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;

--- a/apps/web/src/lib/travel-utils.ts
+++ b/apps/web/src/lib/travel-utils.ts
@@ -1,4 +1,5 @@
 import {
+  differenceInCalendarDays,
   differenceInDays,
   format,
   formatDistanceToNow,
@@ -38,6 +39,52 @@ export const calculateDDay = (startDate: string): string => {
   if (days === 0) return 'D-Day';
   if (days > 0) return `D-${days}`;
   return `D+${Math.abs(days)}`;
+};
+
+/**
+ * 여행 시작/종료일을 고려한 D-Day를 계산합니다.
+ * - 시작 전: D-{n}
+ * - 시작일: D-Day
+ * - 진행 중: D+{시작 이후 경과일}
+ * - 종료 후: 여행 종료 D+{종료 이후 경과일}일
+ */
+export const calculateDDayWithEnd = (
+  startDate: string,
+  endDate: string
+): string => {
+  const today = new Date();
+  const start = parseISO(startDate);
+  const end = parseISO(endDate);
+
+  // 날짜 단위 비교를 위해 캘린더 일수 기반으로 계산
+  const daysUntilStart = differenceInCalendarDays(start, today);
+  if (daysUntilStart > 0) return `D-${daysUntilStart}`;
+  if (daysUntilStart === 0) return 'D-Day';
+
+  const daysUntilEnd = differenceInCalendarDays(today, end);
+  // 진행 중 (오늘이 종료일 이전 또는 같은 날)
+  if (differenceInCalendarDays(today, start) >= 0 && daysUntilEnd <= 0) {
+    const daysSinceStart = Math.abs(daysUntilStart);
+    return daysSinceStart === 0 ? 'D-Day' : `D+${daysSinceStart}`;
+  }
+
+  // 종료 후
+  const daysSinceEnd = differenceInCalendarDays(today, end);
+  return `여행 종료 D+${daysSinceEnd}일`;
+};
+
+/**
+ * "X박 Y일" 형식의 여행 기간 문자열을 반환합니다.
+ */
+export const formatTripNightsDays = (
+  startDate: string,
+  endDate: string
+): string => {
+  const start = parseISO(startDate);
+  const end = parseISO(endDate);
+  const days = differenceInCalendarDays(end, start) + 1;
+  const nights = Math.max(0, days - 1);
+  return `${nights}박 ${days}일`;
 };
 
 /**

--- a/apps/web/src/types/travel/travel.ts
+++ b/apps/web/src/types/travel/travel.ts
@@ -163,7 +163,7 @@ export interface Activity {
   user_id: string;
   action_type: string;
   description: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
   created_at: string;
   updated_at: string;
   user?: {

--- a/packages/ui/src/components/progress/progress.tsx
+++ b/packages/ui/src/components/progress/progress.tsx
@@ -136,7 +136,7 @@ export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
       <div ref={ref} className={clsx('w-full', className)} {...rest}>
         {/* 라벨과 진행률 텍스트 */}
         {(label || showValue) && (
-          <div className='mb-1 flex items-center justify-between'>
+          <div className='flex items-center justify-between'>
             {label && (
               <span
                 className={clsx('font-medium text-gray-700', sizeStyle.text)}


### PR DESCRIPTION
## 📝 설명
여행 준비율 계산 방식을 계획율로 개편하고, 데이터 반영 로직과 UI 세부 스타일을 수정했습니다.

### 🚀  주요 변경사항
- 여행 준비율 계산 방식을 계획율로 개편하고, UX 개선을 통해 가독성과 일관성을 강화했습니다.  
- 데이터 반영 로직과 UI 세부 스타일을 정리하여 안정성과 유지보수성을 확보했습니다.  

## 상세 변경사항
- **D-day 로직 수정 및 스타일 정리**  

- **데이터 최신화 로직 개선**  
  - `useTravelDetail`, `useBlocks`: `refetchOnMount`/`windowFocus` `'always'`, `staleTime` = `0`  
  - `useTravelDetail`: `select`로 캐시 병합 처리(`participants.isOnline` 덮임 방지)  

- **여행 계획율 도입 및 UX 개선**  
  - `planning-calculator` 추가: 점수 = 블록(85%) + 투두(15%)  
  - `usePlanningProgress` 훅 추가 (블록/투두 카운트 기반)  
  - `BriefingBoard`: 준비율 → 계획율 교체, 안내 문구 적용, 추천 리스트/헤더 섹션 제거  
  - 계획율 산정 시 메모 블록 제외  
  
- https://github.com/SeungJin051/trelio/pull/19
