### PR TITLE
feat: 초대 링크 권한/스코프 적용

### DIFF
--- a/apps/web/src/app/(home)/after-login.tsx
+++ b/apps/web/src/app/(home)/after-login.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { Typography } from '@ui/components';
 
+import InvitedTravelWidget from '@/components/travel/overview/InvitedTravelWidget';
 import RecentActivitiesWidget from '@/components/travel/overview/RecentActivitiesWidget';
 import TravelPlansList from '@/components/travel/overview/TravelPlansList';
 
@@ -24,7 +25,7 @@ const AfterLoginHomeView = () => {
         {/* 대시보드 위젯들 */}
         <div className='mb-8 grid gap-6 lg:grid-cols-2'>
           {/* 초대받은 여행 목록 위젯 */}
-          초대받은 여행 목록
+          <InvitedTravelWidget />
           {/* 최근 활동 위젯 */}
           <RecentActivitiesWidget />
         </div>

--- a/apps/web/src/app/api/invites/plan/[shareId]/accept/route.ts
+++ b/apps/web/src/app/api/invites/plan/[shareId]/accept/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createServerSupabaseClient } from '@/lib/supabase/client/supabase-server';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ shareId: string }> }
+) {
+  try {
+    const { shareId } = await params;
+    const supabase = await createServerSupabaseClient();
+
+    // auth
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data, error } = await supabase.rpc('fn_accept_share_link', {
+      p_share_id: shareId,
+      p_user_id: user.id,
+    });
+
+    if (error) {
+      const msg = String(error.message || '').toUpperCase();
+      if (msg.includes('NOT_FOUND'))
+        return NextResponse.json({ error: 'Not found' }, { status: 404 });
+      if (msg.includes('ALREADY_PARTICIPANT'))
+        return NextResponse.json({ error: 'Already' }, { status: 409 });
+      if (msg.includes('PARTICIPATION_LIMIT_EXCEEDED'))
+        return NextResponse.json({ error: 'Limit' }, { status: 422 });
+      return NextResponse.json({ error: 'Join failed' }, { status: 500 });
+    }
+
+    const row = Array.isArray(data) ? data[0] : data;
+    return NextResponse.json({ planId: row.plan_id }, { status: 200 });
+  } catch (_err) {
+    return NextResponse.json({ error: 'Unexpected error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/invites/plan/[shareId]/route.ts
+++ b/apps/web/src/app/api/invites/plan/[shareId]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createServerSupabaseClient } from '@/lib/supabase/client/supabase-server';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ shareId: string }> }
+) {
+  try {
+    const { shareId } = await params;
+    const supabase = await createServerSupabaseClient();
+
+    // UUID 형식 검증
+    const isUuid = /^[0-9a-fA-F-]{36}$/.test(shareId);
+    if (!isUuid) {
+      return NextResponse.json(
+        { error: 'Invalid share id', shareId },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await supabase.rpc('fn_verify_share_link', {
+      p_share_id: shareId,
+    });
+
+    if (error) {
+      console.error('[verify_share_link] RPC error', error);
+      return NextResponse.json(
+        { error: 'RPC error', detail: String(error.message || '') },
+        { status: 500 }
+      );
+    }
+
+    const row = Array.isArray(data)
+      ? (data[0] as { plan_id: string; title: string } | undefined)
+      : (data as { plan_id: string; title: string } | null);
+    if (!row)
+      return NextResponse.json(
+        { error: 'Not found', shareId },
+        { status: 404 }
+      );
+
+    return NextResponse.json({ planId: row.plan_id, title: row.title });
+  } catch (err) {
+    console.error('[verify_share_link] Unexpected error', err);
+    return NextResponse.json(
+      {
+        error: 'Unexpected error',
+        detail: String((err as any)?.message || ''),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -72,13 +72,17 @@ export async function GET(request: NextRequest) {
           }
 
           if (profile) {
-            // 프로필이 존재하는 경우 - 메인 페이지로 리다이렉트
-            return NextResponse.redirect(new URL('/', requestUrl.origin));
+            // 프로필이 존재하는 경우 - next가 있으면 next로, 없으면 홈으로
+            const redirectUrl = next
+              ? new URL(next, requestUrl.origin)
+              : new URL('/', requestUrl.origin);
+            return NextResponse.redirect(redirectUrl);
           } else {
-            // 프로필이 없는 경우 - 회원가입 페이지로 리다이렉트
-            return NextResponse.redirect(
-              new URL('/sign-up', requestUrl.origin)
-            );
+            // 프로필이 없는 경우 - 회원가입 페이지로 리다이렉트 (next 유지)
+            const signUpUrl = new URL('/sign-up', requestUrl.origin);
+            if (next && next.startsWith('/'))
+              signUpUrl.searchParams.set('next', next);
+            return NextResponse.redirect(signUpUrl);
           }
         }
       } catch (profileCheckError) {
@@ -89,10 +93,10 @@ export async function GET(request: NextRequest) {
     }
 
     // next 파라미터가 있으면 해당 페이지로, 없으면 홈으로 리다이렉트
-    const redirectUrl = next
+    const fallbackUrl = next
       ? new URL(next, requestUrl.origin)
       : new URL('/', requestUrl.origin);
-    return NextResponse.redirect(redirectUrl);
+    return NextResponse.redirect(fallbackUrl);
   } catch (error) {
     console.error('콜백 처리 중 예외 발생:', error);
     // 예외 발생 시 로그인 페이지로 리다이렉트

--- a/apps/web/src/app/invite/p/[shareId]/page.tsx
+++ b/apps/web/src/app/invite/p/[shareId]/page.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useParams, useRouter } from 'next/navigation';
+
+import { IoPeopleOutline, IoShieldCheckmarkOutline } from 'react-icons/io5';
+
+import { Button, Typography } from '@ui/components';
+
+import { useSession } from '@/hooks/useSession';
+import { acceptShareLink, verifyShareLink } from '@/lib/api/invites';
+
+const InviteSharePage = () => {
+  const params = useParams();
+  const router = useRouter();
+  const { session, loading } = useSession() as {
+    session: unknown;
+    loading: boolean;
+  };
+  const shareId = params.shareId as string;
+
+  const [loadingVerify, setLoadingVerify] = useState(true);
+  const [plan, setPlan] = useState<{ planId: string; title: string } | null>(
+    null
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [banner, setBanner] = useState<null | {
+    type: 'error' | 'info';
+    text: string;
+    ctaLabel?: string;
+    ctaAction?: () => void;
+  }>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const data = await verifyShareLink(shareId);
+      if (!mounted) return;
+      setPlan(data);
+      setLoadingVerify(false);
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [shareId]);
+
+  const title = useMemo(() => {
+    if (loadingVerify) return '초대 확인 중...';
+    if (plan) return `여행 참여 확인`;
+    return '초대 링크가 유효하지 않습니다';
+  }, [loadingVerify, plan]);
+
+  const handleAccept = async () => {
+    if (!plan) return;
+    if (!session && !loading) {
+      router.replace(`/log-in?next=/invite/p/${shareId}`);
+      return;
+    }
+    try {
+      setSubmitting(true);
+      const res = await acceptShareLink(shareId);
+      router.replace(`/travel/${res.planId}`);
+    } catch (err: any) {
+      const code = String(err?.message || 'ERROR');
+      if (code === 'UNAUTHORIZED') {
+        setBanner({
+          type: 'info',
+          text: '로그인이 필요합니다. 로그인 후 이 페이지로 돌아옵니다.',
+          ctaLabel: '로그인하기',
+          ctaAction: () => router.replace(`/log-in?next=/invite/p/${shareId}`),
+        });
+        return;
+      }
+      if (code === 'ALREADY_PARTICIPANT') {
+        setBanner({
+          type: 'info',
+          text: '이미 참여 중인 여행입니다.',
+          ctaLabel: '여행으로 이동',
+          ctaAction: () => router.replace(`/travel/${plan!.planId}`),
+        });
+        return;
+      }
+      if (code === 'PARTICIPATION_LIMIT_EXCEEDED') {
+        setBanner({
+          type: 'error',
+          text: '참여 가능한 최대 여행 수(3개)를 초과했습니다.',
+        });
+        return;
+      }
+      setBanner({ type: 'error', text: '참여 처리에 실패했습니다.' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className='min-h-screen w-full bg-gray-50'>
+      <div className='mx-auto flex max-w-lg flex-col items-center px-4 py-16'>
+        <div className='mb-6 rounded-full bg-blue-100 p-3 text-blue-600'>
+          <IoPeopleOutline className='h-6 w-6' />
+        </div>
+
+        <Typography variant='h4' className='mb-2 text-center'>
+          {title}
+        </Typography>
+
+        {loadingVerify && (
+          <div className='mt-6 w-full rounded-xl bg-white p-5 shadow-sm'>
+            <div className='space-y-3'>
+              <div className='h-6 w-40 animate-pulse rounded bg-gray-200' />
+              <div className='h-4 w-full animate-pulse rounded bg-gray-100' />
+              <div className='h-4 w-2/3 animate-pulse rounded bg-gray-100' />
+            </div>
+          </div>
+        )}
+
+        {!loadingVerify && plan && (
+          <div className='mt-6 w-full rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
+            <div className='mb-4 flex items-start gap-3'>
+              <div className='rounded-md bg-gray-100 p-2 text-gray-600'>
+                <IoShieldCheckmarkOutline className='h-5 w-5' />
+              </div>
+              <div className='flex-1'>
+                <Typography variant='h6' className='mb-1 text-gray-900'>
+                  {plan.title} 여행에 참여
+                </Typography>
+                <Typography variant='body2' className='text-gray-600'>
+                  참여를 누르면 이 여행의 일정과 공동 할 일을 함께 관리할 수
+                  있어요.
+                </Typography>
+              </div>
+            </div>
+
+            {banner && (
+              <div
+                className={`mb-4 rounded-lg p-3 text-sm ${
+                  banner.type === 'error'
+                    ? 'border border-red-100 bg-red-50 text-red-700'
+                    : 'border border-blue-100 bg-blue-50 text-blue-700'
+                }`}
+              >
+                <div className='flex items-center justify-between gap-3'>
+                  <span>{banner.text}</span>
+                  {banner.ctaLabel && banner.ctaAction && (
+                    <Button
+                      onClick={banner.ctaAction}
+                      variant='outlined'
+                      colorTheme={banner.type === 'error' ? 'red' : 'blue'}
+                      size='small'
+                    >
+                      {banner.ctaLabel}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div className='mt-5 flex gap-2'>
+              <Button
+                onClick={handleAccept}
+                disabled={submitting}
+                variant='filled'
+                colorTheme='blue'
+                className='flex-1'
+              >
+                참여하기
+              </Button>
+              <Button
+                onClick={() => router.replace('/')}
+                variant='outlined'
+                colorTheme='gray'
+                className='flex-1'
+              >
+                나중에 할게요
+              </Button>
+            </div>
+
+            {!session && (
+              <div className='mt-3 text-center'>
+                <Typography variant='caption' className='text-gray-500'>
+                  참여에는 로그인이 필요합니다. 참여하기를 누르면 로그인 후 이
+                  페이지로 돌아와요.
+                </Typography>
+              </div>
+            )}
+          </div>
+        )}
+
+        {!loadingVerify && !plan && (
+          <div className='mt-6 w-full rounded-xl border border-red-100 bg-red-50 p-6 text-center'>
+            <Typography variant='body2' className='mb-2 text-red-700'>
+              초대 링크가 유효하지 않습니다.
+            </Typography>
+            <Typography variant='caption' className='text-red-600'>
+              링크가 만료되었거나 잘못된 주소일 수 있어요.
+            </Typography>
+            <div className='mt-4'>
+              <Button
+                onClick={() => router.replace('/')}
+                variant='filled'
+                colorTheme='gray'
+              >
+                홈으로 돌아가기
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InviteSharePage;

--- a/apps/web/src/app/invite/p/[shareId]/page.tsx
+++ b/apps/web/src/app/invite/p/[shareId]/page.tsx
@@ -88,6 +88,25 @@ const InviteSharePage = () => {
         });
         return;
       }
+      if (code === 'LINK_EXPIRED') {
+        setBanner({ type: 'error', text: '초대 링크가 만료되었습니다.' });
+        return;
+      }
+      if (code === 'INVALID_REQUEST') {
+        setBanner({ type: 'error', text: '유효하지 않은 요청입니다.' });
+        return;
+      }
+      if (code === 'LINK_CLOSED') {
+        setBanner({
+          type: 'error',
+          text: '이 초대는 더 이상 유효하지 않습니다.',
+        });
+        return;
+      }
+      if (code.startsWith('FAILED:')) {
+        setBanner({ type: 'error', text: `참여 실패: ${code.substring(7)}` });
+        return;
+      }
       setBanner({ type: 'error', text: '참여 처리에 실패했습니다.' });
     } finally {
       setSubmitting(false);

--- a/apps/web/src/app/log-in/page.tsx
+++ b/apps/web/src/app/log-in/page.tsx
@@ -1,5 +1,11 @@
+import { Suspense } from 'react';
+
 import LoginView from './view';
 
 export default function LoginPage() {
-  return <LoginView />;
+  return (
+    <Suspense fallback={<div />}>
+      <LoginView />
+    </Suspense>
+  );
 }

--- a/apps/web/src/app/log-in/view.tsx
+++ b/apps/web/src/app/log-in/view.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 import { BiSolidMessageRounded } from 'react-icons/bi';
@@ -18,6 +18,7 @@ import { getURL } from '@/lib/utils';
 const LoginView = () => {
   const supabase = createClient();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const toast = useToast();
 
   const [isLoading, setIsLoading] = useState<{ [key: string]: boolean }>({
@@ -118,10 +119,12 @@ const LoginView = () => {
       setIsLoading((prev) => ({ ...prev, kakao: true }));
 
       // Supabase Auth를 통한 카카오 OAuth 로그인 시작
+      const next = searchParams.get('next');
+      const safeNext = next && next.startsWith('/') ? next : null;
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'kakao',
         options: {
-          redirectTo: `${getURL()}auth/callback`,
+          redirectTo: `${getURL()}auth/callback${safeNext ? `?next=${encodeURIComponent(safeNext)}` : ''}`,
           scopes: 'profile_nickname profile_image account_email',
           queryParams: {
             prompt: 'login',
@@ -174,10 +177,12 @@ const LoginView = () => {
     try {
       setIsLoading((prev) => ({ ...prev, google: true }));
 
+      const next = searchParams.get('next');
+      const safeNext = next && next.startsWith('/') ? next : null;
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${getURL()}auth/callback`,
+          redirectTo: `${getURL()}auth/callback${safeNext ? `?next=${encodeURIComponent(safeNext)}` : ''}`,
           scopes: 'openid email profile',
           queryParams: {
             prompt: 'consent',

--- a/apps/web/src/app/log-in/view.tsx
+++ b/apps/web/src/app/log-in/view.tsx
@@ -54,8 +54,10 @@ const LoginView = () => {
             // 프로필이 존재하는 경우 - 메인 페이지로 리다이렉트
             router.push('/');
           } else {
-            // 프로필이 없는 경우 - 회원가입 페이지로 리다이렉트
-            router.push('/sign-up');
+            // 프로필이 없는 경우 - 회원가입 페이지로 리다이렉트 (next 유지)
+            const next = searchParams.get('next');
+            const safeNext = next && next.startsWith('/') ? next : '/';
+            router.push(`/sign-up?next=${encodeURIComponent(safeNext)}`);
           }
         } catch (error) {
           console.error('자동 로그인 중 프로필 확인 오류:', error);
@@ -89,9 +91,11 @@ const LoginView = () => {
               // 프로필이 존재하는 경우 - 메인 페이지로 리다이렉트
               router.push('/');
             } else {
-              // 프로필이 없는 경우 - 회원가입 페이지로 리다이렉트
+              // 프로필이 없는 경우 - 회원가입 페이지로 리다이렉트 (next 유지)
               toast.success('환영합니다! 프로필을 설정해주세요.');
-              router.push('/sign-up');
+              const next = searchParams.get('next');
+              const safeNext = next && next.startsWith('/') ? next : '/';
+              router.push(`/sign-up?next=${encodeURIComponent(safeNext)}`);
             }
           } catch (error) {
             console.error('onAuthStateChange 프로필 확인 중 오류:', error);

--- a/apps/web/src/app/log-in/view.tsx
+++ b/apps/web/src/app/log-in/view.tsx
@@ -167,6 +167,56 @@ const LoginView = () => {
     }
   };
 
+  /**
+   * 구글 소셜 로그인 처리 함수 (Supabase OAuth - Google)
+   */
+  const handleGoogleLogin = async () => {
+    try {
+      setIsLoading((prev) => ({ ...prev, google: true }));
+
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: `${getURL()}auth/callback`,
+          scopes: 'openid email profile',
+          queryParams: {
+            prompt: 'consent',
+            access_type: 'offline',
+          },
+        },
+      });
+
+      if (error) {
+        console.error('구글 로그인 에러:', error);
+        switch (error.message) {
+          case 'Email not confirmed':
+            toast.error('이메일 인증이 필요합니다. 이메일을 확인해주세요.');
+            break;
+          case 'Invalid login credentials':
+            toast.error('로그인 정보가 올바르지 않습니다.');
+            break;
+          case 'Too many requests':
+            toast.error('요청이 많습니다. 잠시 후 다시 시도해주세요.');
+            break;
+          default:
+            toast.error(
+              '구글 로그인 중 오류가 발생했습니다. 다시 시도해주세요.'
+            );
+        }
+        return;
+      }
+
+      if (data?.url) {
+        window.location.href = data.url;
+      }
+    } catch (error) {
+      console.error('구글 로그인 예외:', error);
+      toast.error('로그인 처리 중 문제가 발생했습니다.');
+    } finally {
+      setIsLoading((prev) => ({ ...prev, google: false }));
+    }
+  };
+
   return (
     <div className='flex min-h-screen items-start justify-center pt-[10vh]'>
       <div className='h-[650px] rounded-2xl bg-white shadow-sm'>
@@ -212,7 +262,7 @@ const LoginView = () => {
 
             {/* 구글 로그인 버튼 */}
             <button
-              onClick={() => {}}
+              onClick={handleGoogleLogin}
               disabled={isLoading.google || isLoading.kakao}
               className='flex w-full items-center justify-center rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-200 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-70'
             >

--- a/apps/web/src/app/sign-up/page.tsx
+++ b/apps/web/src/app/sign-up/page.tsx
@@ -1,7 +1,13 @@
+import { Suspense } from 'react';
+
 import SignUpView from './view';
 
 const SignUpPage = () => {
-  return <SignUpView />;
+  return (
+    <Suspense fallback={<div />}>
+      <SignUpView />
+    </Suspense>
+  );
 };
 
 export default SignUpPage;

--- a/apps/web/src/app/sign-up/view.tsx
+++ b/apps/web/src/app/sign-up/view.tsx
@@ -13,6 +13,7 @@ import { Avatar, Button, Icon, Input, Typography } from '@ui/components';
 import { Card } from '@/components';
 import LocationInput from '@/components/travel/inputs/LocationInput';
 import { useToast } from '@/hooks';
+import { useSession } from '@/hooks/useSession';
 import { createClient } from '@/lib/supabase/client/supabase';
 import type { TravelStyle, UserProfile } from '@/types/user/user';
 
@@ -35,6 +36,7 @@ const SignUpView = () => {
   const searchParams = useSearchParams();
   const toast = useToast();
   const supabase = createClient();
+  const { refreshProfile } = useSession();
   const progress = (step / TOTAL_STEPS) * 100;
 
   // 이미지 업로드 훅 사용
@@ -159,8 +161,14 @@ const SignUpView = () => {
         return;
       }
 
-      // 프로필 저장 후 잠시 대기하여 사용자에게 성공 메시지를 보여줌
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      // 전역 세션 훅 상태 갱신하여 'incomplete' 리다이렉트 가드를 해제
+      try {
+        await refreshProfile();
+      } catch (e) {
+        console.warn('refreshProfile failed', e);
+      }
+      // 사용자에게 피드백 노출 여유
+      await new Promise((resolve) => setTimeout(resolve, 500));
 
       // next 처리: 초대 수락 흐름이면 수락 후 해당 여행 상세로 이동
       const next = searchParams.get('next');

--- a/apps/web/src/app/sign-up/view.tsx
+++ b/apps/web/src/app/sign-up/view.tsx
@@ -161,8 +161,9 @@ const SignUpView = () => {
       // 프로필 저장 후 잠시 대기하여 사용자에게 성공 메시지를 보여줌
       await new Promise((resolve) => setTimeout(resolve, 1500));
 
-      // 메인 페이지로 리다이렉트
-      router.push('/');
+      // 메인 페이지로 리다이렉트 (히스토리 교체로 복귀 방지)
+      router.replace('/');
+      return;
     } catch (error) {
       if (error instanceof Error) {
         toast.error(`회원가입 실패: ${error.message}`);

--- a/apps/web/src/app/travel/[id]/view.tsx
+++ b/apps/web/src/app/travel/[id]/view.tsx
@@ -12,6 +12,7 @@ import LoadingView from '@/components/basic/Loading/Loading';
 import { BlockCreateModal } from '@/components/travel/detail/BlockCreateModal';
 import { BlockDetailModal } from '@/components/travel/detail/BlockDetailModal';
 import { TravelTimelineCanvas } from '@/components/travel/detail/TravelTimelineCanvas';
+import InviteLinkModal from '@/components/travel/modals/InviteLinkModal';
 import { useBlocks } from '@/hooks/useBlocks';
 import { useParticipantsPresence } from '@/hooks/useParticipantsPresence';
 import { useSession } from '@/hooks/useSession';
@@ -39,6 +40,7 @@ const TravelDetailView = () => {
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showDetailModal, setShowDetailModal] = useState(false);
+  const [showInviteModal, setShowInviteModal] = useState(false);
   const [selectedBlock, setSelectedBlock] = useState<TravelBlock | null>(null);
   const [selectedDay, setSelectedDay] = useState<number>(0); // 0은 대시보드
 
@@ -166,7 +168,7 @@ const TravelDetailView = () => {
   }
 
   const handleInviteParticipants = () => {
-    toast('동반자 초대 기능은 준비 중입니다.');
+    setShowInviteModal(true);
   };
 
   const handleExport = () => {
@@ -208,6 +210,11 @@ const TravelDetailView = () => {
 
   // 편집 권한 확인 (임시로 true, 나중에 실제 권한 체크 로직으로 교체)
   const canEdit = true;
+  const isOwner = Boolean(
+    travelPlan?.owner_id &&
+      userProfile?.id &&
+      travelPlan.owner_id === userProfile.id
+  );
 
   return (
     <div className='flex min-h-screen w-full bg-gray-50'>
@@ -339,6 +346,17 @@ const TravelDetailView = () => {
           block={selectedBlock}
           onDelete={deleteBlock}
           canEdit={canEdit}
+        />
+      )}
+
+      {showInviteModal && (
+        <InviteLinkModal
+          isOpen={showInviteModal}
+          onClose={() => setShowInviteModal(false)}
+          planId={planId}
+          shareLinkId={(travelPlan as any).share_link_id}
+          participants={participants as any}
+          isOwner={isOwner}
         />
       )}
     </div>

--- a/apps/web/src/components/layout/Footer/Footer.tsx
+++ b/apps/web/src/components/layout/Footer/Footer.tsx
@@ -16,12 +16,7 @@ export const Footer = () => {
   };
 
   // 개인 프로젝트에 필요한 최소한의 링크만 유지
-  const footerLinks = [
-    { name: '여행 목록', href: '/travel-list' },
-    { name: '요금제', href: '/price' },
-    { name: 'FAQ', href: '/faq' },
-    { name: '문의하기', href: '/contact' },
-  ];
+  const footerLinks = [{ name: '문의하기', href: '/contact' }];
 
   const socialLinks = [
     { name: 'Github', href: 'https://github.com/SeungJin051', icon: 'github' },

--- a/apps/web/src/components/layout/Header/constants.ts
+++ b/apps/web/src/components/layout/Header/constants.ts
@@ -10,12 +10,7 @@ export interface NavItem {
   href: string;
 }
 
-export const navigation: NavItem[] = [
-  { name: '여행 목록', href: '/travel-list' },
-  { name: '요금제', href: '/price' },
-  { name: 'FAQ', href: '/faq' },
-  { name: '문의하기', href: '/contact' },
-];
+export const navigation: NavItem[] = [];
 
 // 여행 계획 필터 옵션
 export const filterOptions = [

--- a/apps/web/src/components/travel/modals/InviteLinkModal.tsx
+++ b/apps/web/src/components/travel/modals/InviteLinkModal.tsx
@@ -2,7 +2,14 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { IoCopyOutline, IoLinkOutline } from 'react-icons/io5';
+import {
+  IoCopyOutline,
+  IoCreateOutline,
+  IoEyeOutline,
+  IoGlobeOutline,
+  IoLinkOutline,
+  IoPersonOutline,
+} from 'react-icons/io5';
 
 import { Avatar, Button, Input, Typography } from '@ui/components';
 
@@ -37,6 +44,10 @@ const InviteLinkModal: React.FC<InviteLinkModalProps> = ({
   const supabase = createClient();
   const [shareUrl, setShareUrl] = useState('');
   const [localParticipants, setLocalParticipants] = useState(participants);
+  const [accessScope, setAccessScope] = useState<'anyone' | 'owner'>('anyone');
+  const [accessPermission, setAccessPermission] = useState<'edit' | 'view'>(
+    'edit'
+  );
 
   const value = useMemo(() => shareUrl, [shareUrl]);
 
@@ -64,18 +75,77 @@ const InviteLinkModal: React.FC<InviteLinkModalProps> = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose} title='동반자 초대' width='lg'>
       <div className='space-y-4 px-6 py-5'>
-        <div>
-          <Typography variant='body2' className='mb-2 text-gray-700'>
-            현재 주소
+        {/* 액세스 수준 */}
+        <div className='space-y-2'>
+          <Typography variant='body2' className='text-gray-700'>
+            액세스 수준
           </Typography>
+          <div className='flex w-full gap-2'>
+            <div
+              className={`min-w-0 ${
+                accessScope === 'owner' ? 'basis-full' : 'basis-[70%]'
+              }`}
+            >
+              <label className='mb-1 block text-xs text-gray-500'>
+                접근 대상
+              </label>
+              <div className='relative'>
+                <span className='pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-gray-500'>
+                  {accessScope === 'anyone' ? (
+                    <IoGlobeOutline className='h-4 w-4' />
+                  ) : (
+                    <IoPersonOutline className='h-4 w-4' />
+                  )}
+                </span>
+                <select
+                  disabled={!isOwner}
+                  value={accessScope}
+                  onChange={(e) =>
+                    setAccessScope(
+                      (e.target.value as 'anyone' | 'owner') || 'anyone'
+                    )
+                  }
+                  className='w-full rounded border border-gray-300 bg-white py-2 pl-8 pr-2 text-sm'
+                >
+                  <option value='anyone'>링크가 있는 모든 사용자</option>
+                  <option value='owner'>본인만 액세스 가능</option>
+                </select>
+              </div>
+            </div>
+            {accessScope !== 'owner' && (
+              <div className='min-w-0 basis-[30%]'>
+                <label className='mb-1 block text-xs text-gray-500'>
+                  권한 수준
+                </label>
+                <div className='relative'>
+                  <span className='pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-gray-500'>
+                    {accessPermission === 'edit' ? (
+                      <IoCreateOutline className='h-4 w-4' />
+                    ) : (
+                      <IoEyeOutline className='h-4 w-4' />
+                    )}
+                  </span>
+                  <select
+                    disabled={!isOwner}
+                    value={accessPermission}
+                    onChange={(e) =>
+                      setAccessPermission(
+                        (e.target.value as 'edit' | 'view') || 'view'
+                      )
+                    }
+                    className='w-full rounded border border-gray-300 bg-white py-2 pl-8 pr-2 text-sm'
+                  >
+                    <option value='edit'>편집 가능</option>
+                    <option value='view'>보기 가능</option>
+                  </select>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div>
           <div className='flex flex-col gap-2'>
-            <Input
-              value={value}
-              readOnly
-              placeholder='생성된 링크가 여기에 표시됩니다'
-              className='w-full'
-              leftIcon={<IoLinkOutline className='h-4 w-4' />}
-            />
             <Button
               onClick={handleCopy}
               variant='filled'

--- a/apps/web/src/components/travel/modals/InviteLinkModal.tsx
+++ b/apps/web/src/components/travel/modals/InviteLinkModal.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { IoCopyOutline, IoLinkOutline } from 'react-icons/io5';
+
+import { Avatar, Button, Input, Typography } from '@ui/components';
+
+import { Modal } from '@/components/basic';
+import { useToast } from '@/hooks/useToast';
+import { createClient } from '@/lib/supabase/client/supabase';
+
+interface InviteLinkModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  planId: string;
+  shareLinkId: string;
+  participants: Array<{
+    id: string;
+    user_id: string;
+    role: 'owner' | 'editor' | 'viewer';
+    nickname?: string;
+    profile_image_url?: string;
+  }>;
+  isOwner?: boolean;
+}
+
+const InviteLinkModal: React.FC<InviteLinkModalProps> = ({
+  isOpen,
+  onClose,
+  planId,
+  shareLinkId,
+  participants,
+  isOwner = false,
+}) => {
+  const toast = useToast();
+  const supabase = createClient();
+  const [shareUrl, setShareUrl] = useState('');
+  const [localParticipants, setLocalParticipants] = useState(participants);
+
+  const value = useMemo(() => shareUrl, [shareUrl]);
+
+  useEffect(() => {
+    const origin = typeof window !== 'undefined' ? window.location.origin : '';
+    setShareUrl(`${origin}/invite/p/${shareLinkId}`);
+  }, [shareLinkId]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success('링크를 복사했어요');
+    } catch {
+      // fallback
+      const temp = document.createElement('textarea');
+      temp.value = value;
+      document.body.appendChild(temp);
+      temp.select();
+      document.execCommand('copy');
+      document.body.removeChild(temp);
+      toast.success('링크를 복사했어요');
+    }
+  }, [toast, value]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title='동반자 초대' width='lg'>
+      <div className='space-y-4 px-6 py-5'>
+        <div>
+          <Typography variant='body2' className='mb-2 text-gray-700'>
+            현재 주소
+          </Typography>
+          <div className='flex flex-col gap-2'>
+            <Input
+              value={value}
+              readOnly
+              placeholder='생성된 링크가 여기에 표시됩니다'
+              className='w-full'
+              leftIcon={<IoLinkOutline className='h-4 w-4' />}
+            />
+            <Button
+              onClick={handleCopy}
+              variant='filled'
+              colorTheme='blue'
+              className='w-full'
+              disabled={!value}
+              leftIcon={<IoCopyOutline className='h-4 w-4' />}
+            >
+              링크 복사하기
+            </Button>
+          </div>
+        </div>
+        <div className='rounded-lg bg-gray-50 p-3'>
+          <Typography variant='caption' className='text-gray-600'>
+            동반자에게 링크를 공유하세요. 로그인 후 링크를 열면 이 여행에 참여할
+            수 있습니다. 최대 3개의 여행에 참여할 수 있어요.
+          </Typography>
+        </div>
+        <div className='space-y-3'>
+          <Typography variant='body2' className='text-gray-700'>
+            참여자 관리
+          </Typography>
+          <div className='space-y-2'>
+            {localParticipants.length === 0 ? (
+              <Typography variant='caption' className='text-gray-500'>
+                아직 참여자가 없습니다.
+              </Typography>
+            ) : (
+              localParticipants.map((p) => (
+                <div
+                  key={p.id}
+                  className='flex items-center justify-between rounded border border-gray-200 p-2'
+                >
+                  <div className='flex items-center gap-2'>
+                    <Avatar
+                      src={p.profile_image_url}
+                      alt={p.nickname || p.user_id}
+                      size='small'
+                    />
+                    <div>
+                      <Typography variant='body2' className='text-gray-900'>
+                        {p.nickname || '사용자'}
+                      </Typography>
+                    </div>
+                  </div>
+                  <div className='flex items-center gap-2'>
+                    <select
+                      disabled={!isOwner || p.role === 'owner'}
+                      value={p.role}
+                      onChange={async (e) => {
+                        const newRole = e.target.value as
+                          | 'viewer'
+                          | 'editor'
+                          | 'owner';
+                        try {
+                          const { error } = await supabase
+                            .from('travel_plan_participants')
+                            .update({ role: newRole })
+                            .eq('id', p.id)
+                            .eq('plan_id', planId);
+                          if (error) throw error;
+                          setLocalParticipants((prev) =>
+                            prev.map((x) =>
+                              x.id === p.id ? { ...x, role: newRole } : x
+                            )
+                          );
+                          toast.success('권한을 변경했어요');
+                        } catch {
+                          toast.error('권한 변경에 실패했어요');
+                        }
+                      }}
+                      className='rounded border border-gray-300 px-2 py-1 text-sm'
+                    >
+                      <option value='viewer'>viewer</option>
+                      <option value='editor'>editor</option>
+                      <option value='owner' disabled>
+                        owner
+                      </option>
+                    </select>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default InviteLinkModal;

--- a/apps/web/src/components/travel/modals/InviteLinkModal.tsx
+++ b/apps/web/src/components/travel/modals/InviteLinkModal.tsx
@@ -72,6 +72,44 @@ const InviteLinkModal: React.FC<InviteLinkModalProps> = ({
     }
   }, [toast, value]);
 
+  // 액세스 수준 변경 핸들러 (DB 반영)
+  const handleScopeChange = useCallback(
+    async (next: 'anyone' | 'owner') => {
+      try {
+        setAccessScope(next);
+        if (!isOwner) return;
+        const { error } = await supabase
+          .from('travel_plans')
+          .update({ share_link_scope: next })
+          .eq('id', planId);
+        if (error) throw error;
+        toast.success('접근 대상을 업데이트했어요');
+      } catch {
+        toast.error('접근 대상 업데이트에 실패했어요');
+      }
+    },
+    [isOwner, planId, supabase, toast]
+  );
+
+  const handlePermissionChange = useCallback(
+    async (next: 'edit' | 'view') => {
+      try {
+        setAccessPermission(next);
+        if (!isOwner) return;
+        const mapped = next === 'edit' ? 'editor' : 'viewer';
+        const { error } = await supabase
+          .from('travel_plans')
+          .update({ default_permission: mapped })
+          .eq('id', planId);
+        if (error) throw error;
+        toast.success('권한 수준을 업데이트했어요');
+      } catch {
+        toast.error('권한 수준 업데이트에 실패했어요');
+      }
+    },
+    [isOwner, planId, supabase, toast]
+  );
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} title='동반자 초대' width='lg'>
       <div className='space-y-4 px-6 py-5'>
@@ -101,7 +139,7 @@ const InviteLinkModal: React.FC<InviteLinkModalProps> = ({
                   disabled={!isOwner}
                   value={accessScope}
                   onChange={(e) =>
-                    setAccessScope(
+                    handleScopeChange(
                       (e.target.value as 'anyone' | 'owner') || 'anyone'
                     )
                   }
@@ -129,7 +167,7 @@ const InviteLinkModal: React.FC<InviteLinkModalProps> = ({
                     disabled={!isOwner}
                     value={accessPermission}
                     onChange={(e) =>
-                      setAccessPermission(
+                      handlePermissionChange(
                         (e.target.value as 'edit' | 'view') || 'view'
                       )
                     }

--- a/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
+++ b/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
@@ -2,12 +2,17 @@
 
 import React from 'react';
 
+import { useRouter } from 'next/navigation';
+
+import { IoCalendarOutline, IoPeopleOutline } from 'react-icons/io5';
+
 import { Typography } from '@ui/components';
 
 import { useInvitedTravelPlans } from '@/hooks/useTravelPlans';
 
 const InvitedTravelWidget: React.FC = () => {
   const { data: plans = [], isLoading } = useInvitedTravelPlans(5);
+  const router = useRouter();
 
   if (isLoading) {
     return (
@@ -36,15 +41,78 @@ const InvitedTravelWidget: React.FC = () => {
         📩 초대받은 여행
       </Typography>
 
-      <div className='py-8 text-center'>
-        <div className='mb-2 text-4xl'>🗺️</div>
-        <Typography variant='body2' className='mb-1 text-gray-500'>
-          초대받은 여행이 없습니다
-        </Typography>
-        <Typography variant='caption' className='text-gray-400'>
-          초대 링크를 받거나 공유된 여행에 참여해 보세요
-        </Typography>
-      </div>
+      {plans.length === 0 ? (
+        <div className='py-8 text-center'>
+          <div className='mb-2 text-4xl'>🗺️</div>
+          <Typography variant='body2' className='mb-1 text-gray-500'>
+            초대받은 여행이 없습니다
+          </Typography>
+          <Typography variant='caption' className='text-gray-400'>
+            초대 링크를 받거나 공유된 여행에 참여해 보세요
+          </Typography>
+        </div>
+      ) : (
+        <div className='space-y-3'>
+          {plans.map((plan) => {
+            const start = new Date(plan.start_date).toLocaleDateString(
+              'ko-KR',
+              {
+                month: 'short',
+                day: 'numeric',
+              }
+            );
+            const end = new Date(plan.end_date).toLocaleDateString('ko-KR', {
+              month: 'short',
+              day: 'numeric',
+            });
+            return (
+              <div
+                key={plan.id}
+                onClick={() => router.push(`/travel/${plan.id}`)}
+                className='flex cursor-pointer items-start space-x-3 rounded-lg p-3 transition-colors hover:bg-gray-50'
+              >
+                <div className='flex h-8 w-8 items-center justify-center rounded-full bg-blue-50 text-blue-600'>
+                  <IoPeopleOutline className='h-4 w-4' />
+                </div>
+                <div className='min-w-0 flex-1'>
+                  <div className='mb-1 flex items-center justify-between gap-2'>
+                    <Typography
+                      variant='body2'
+                      className='truncate text-gray-900'
+                    >
+                      {plan.title}
+                    </Typography>
+                    <span className='whitespace-nowrap rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600'>
+                      {plan.role === 'owner'
+                        ? '소유자'
+                        : plan.role === 'editor'
+                          ? '편집자'
+                          : '읽기'}
+                    </span>
+                  </div>
+                  <Typography
+                    variant='caption'
+                    className='mb-1 block text-gray-600'
+                  >
+                    {plan.location}
+                  </Typography>
+                  <div className='flex items-center justify-between text-gray-500'>
+                    <div className='flex items-center gap-1'>
+                      <IoCalendarOutline className='h-3.5 w-3.5' />
+                      <Typography variant='caption'>
+                        {start} - {end}
+                      </Typography>
+                    </div>
+                    <Typography variant='caption'>
+                      {plan.participantCount}명
+                    </Typography>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
+++ b/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { IoCalendarOutline, IoPeopleOutline } from 'react-icons/io5';
+
+import { Typography } from '@ui/components';
+
+import { useToast } from '@/hooks/useToast';
+import {
+  useInvitationActions,
+  usePendingInvitations,
+} from '@/hooks/useTravelPlans';
+
+const InvitedTravelWidget: React.FC = () => {
+  const router = useRouter();
+  const toast = useToast();
+  const { data: invitations = [], isLoading } = usePendingInvitations(5);
+  const { acceptInvitation, declineInvitation, accepting, declining } =
+    useInvitationActions();
+
+  if (isLoading) {
+    return (
+      <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+        <div className='animate-pulse'>
+          <div className='mb-4 h-6 w-40 rounded bg-gray-200' />
+          <div className='space-y-3'>
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className='flex items-center space-x-3'>
+                <div className='h-8 w-8 rounded-full bg-gray-200' />
+                <div className='flex-1'>
+                  <div className='mb-1 h-4 rounded bg-gray-200' />
+                  <div className='h-3 w-16 rounded bg-gray-200' />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+      <Typography variant='h6' weight='semiBold' className='mb-4 text-gray-900'>
+        📩 초대받은 여행
+      </Typography>
+
+      {invitations.length === 0 ? (
+        <div className='py-8 text-center'>
+          <div className='mb-2 text-4xl'>🗺️</div>
+          <Typography variant='body2' className='mb-1 text-gray-500'>
+            초대받은 여행이 없습니다
+          </Typography>
+          <Typography variant='caption' className='text-gray-400'>
+            초대 링크를 받거나 공유된 여행에 참여해 보세요
+          </Typography>
+        </div>
+      ) : (
+        <div className='space-y-3'>
+          {invitations.map((inv) => (
+            <button
+              key={inv.id}
+              onClick={() => router.push(`/travel/${inv.plan.id}`)}
+              className='flex w-full items-start space-x-3 rounded-lg p-3 text-left transition-colors hover:bg-gray-50'
+            >
+              <div className='flex h-8 w-8 items-center justify-center rounded-full bg-indigo-50 text-indigo-600'>
+                <IoPeopleOutline className='h-4 w-4' />
+              </div>
+              <div className='min-w-0 flex-1'>
+                <Typography variant='body2' className='mb-1 text-gray-900'>
+                  <span className='font-medium'>
+                    &lsquo;{inv.plan.title}&rsquo;
+                  </span>{' '}
+                  여행에 초대가 왔습니다. 수락하시겠습니까?
+                </Typography>
+                <div className='flex items-center gap-3 text-gray-500'>
+                  <span className='inline-flex items-center gap-1'>
+                    <IoCalendarOutline className='h-3.5 w-3.5' />
+                    <Typography variant='caption'>
+                      {new Date(inv.plan.start_date).toLocaleDateString(
+                        'ko-KR',
+                        {
+                          month: 'short',
+                          day: 'numeric',
+                        }
+                      )}{' '}
+                      –{' '}
+                      {new Date(inv.plan.end_date).toLocaleDateString('ko-KR', {
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </Typography>
+                  </span>
+                </div>
+                <div className='mt-3 flex items-center gap-2'>
+                  <button
+                    className='rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50'
+                    disabled={accepting || declining}
+                    onClick={async (e) => {
+                      e.preventDefault();
+                      try {
+                        await acceptInvitation(inv.id);
+                        toast.success('초대를 수락했어요');
+                      } catch (error) {
+                        toast.error(
+                          error instanceof Error
+                            ? error.message
+                            : '수락에 실패했어요'
+                        );
+                      }
+                    }}
+                  >
+                    예
+                  </button>
+                  <button
+                    className='rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-50'
+                    disabled={accepting || declining}
+                    onClick={async (e) => {
+                      e.preventDefault();
+                      try {
+                        await declineInvitation(inv.id);
+                        toast('초대를 거절했어요');
+                      } catch (error) {
+                        toast.error('거절에 실패했어요');
+                      }
+                    }}
+                  >
+                    아니요
+                  </button>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InvitedTravelWidget;

--- a/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
+++ b/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
@@ -2,24 +2,12 @@
 
 import React from 'react';
 
-import { useRouter } from 'next/navigation';
-
-import { IoCalendarOutline, IoPeopleOutline } from 'react-icons/io5';
-
 import { Typography } from '@ui/components';
 
-import { useToast } from '@/hooks/useToast';
-import {
-  useInvitationActions,
-  usePendingInvitations,
-} from '@/hooks/useTravelPlans';
+import { useInvitedTravelPlans } from '@/hooks/useTravelPlans';
 
 const InvitedTravelWidget: React.FC = () => {
-  const router = useRouter();
-  const toast = useToast();
-  const { data: invitations = [], isLoading } = usePendingInvitations(5);
-  const { acceptInvitation, declineInvitation, accepting, declining } =
-    useInvitationActions();
+  const { data: plans = [], isLoading } = useInvitedTravelPlans(5);
 
   if (isLoading) {
     return (
@@ -48,94 +36,15 @@ const InvitedTravelWidget: React.FC = () => {
         📩 초대받은 여행
       </Typography>
 
-      {invitations.length === 0 ? (
-        <div className='py-8 text-center'>
-          <div className='mb-2 text-4xl'>🗺️</div>
-          <Typography variant='body2' className='mb-1 text-gray-500'>
-            초대받은 여행이 없습니다
-          </Typography>
-          <Typography variant='caption' className='text-gray-400'>
-            초대 링크를 받거나 공유된 여행에 참여해 보세요
-          </Typography>
-        </div>
-      ) : (
-        <div className='space-y-3'>
-          {invitations.map((inv) => (
-            <button
-              key={inv.id}
-              onClick={() => router.push(`/travel/${inv.plan.id}`)}
-              className='flex w-full items-start space-x-3 rounded-lg p-3 text-left transition-colors hover:bg-gray-50'
-            >
-              <div className='flex h-8 w-8 items-center justify-center rounded-full bg-indigo-50 text-indigo-600'>
-                <IoPeopleOutline className='h-4 w-4' />
-              </div>
-              <div className='min-w-0 flex-1'>
-                <Typography variant='body2' className='mb-1 text-gray-900'>
-                  <span className='font-medium'>
-                    &lsquo;{inv.plan.title}&rsquo;
-                  </span>{' '}
-                  여행에 초대가 왔습니다. 수락하시겠습니까?
-                </Typography>
-                <div className='flex items-center gap-3 text-gray-500'>
-                  <span className='inline-flex items-center gap-1'>
-                    <IoCalendarOutline className='h-3.5 w-3.5' />
-                    <Typography variant='caption'>
-                      {new Date(inv.plan.start_date).toLocaleDateString(
-                        'ko-KR',
-                        {
-                          month: 'short',
-                          day: 'numeric',
-                        }
-                      )}{' '}
-                      –{' '}
-                      {new Date(inv.plan.end_date).toLocaleDateString('ko-KR', {
-                        month: 'short',
-                        day: 'numeric',
-                      })}
-                    </Typography>
-                  </span>
-                </div>
-                <div className='mt-3 flex items-center gap-2'>
-                  <button
-                    className='rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50'
-                    disabled={accepting || declining}
-                    onClick={async (e) => {
-                      e.preventDefault();
-                      try {
-                        await acceptInvitation(inv.id);
-                        toast.success('초대를 수락했어요');
-                      } catch (error) {
-                        toast.error(
-                          error instanceof Error
-                            ? error.message
-                            : '수락에 실패했어요'
-                        );
-                      }
-                    }}
-                  >
-                    예
-                  </button>
-                  <button
-                    className='rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-50'
-                    disabled={accepting || declining}
-                    onClick={async (e) => {
-                      e.preventDefault();
-                      try {
-                        await declineInvitation(inv.id);
-                        toast('초대를 거절했어요');
-                      } catch (error) {
-                        toast.error('거절에 실패했어요');
-                      }
-                    }}
-                  >
-                    아니요
-                  </button>
-                </div>
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
+      <div className='py-8 text-center'>
+        <div className='mb-2 text-4xl'>🗺️</div>
+        <Typography variant='body2' className='mb-1 text-gray-500'>
+          초대받은 여행이 없습니다
+        </Typography>
+        <Typography variant='caption' className='text-gray-400'>
+          초대 링크를 받거나 공유된 여행에 참여해 보세요
+        </Typography>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/travel/overview/TravelPlansList.tsx
+++ b/apps/web/src/components/travel/overview/TravelPlansList.tsx
@@ -27,6 +27,8 @@ interface TravelPlan {
   status: 'all' | 'upcoming' | 'in-progress' | 'completed';
   created_at: string;
   participantCount: number;
+  isInvited?: boolean;
+  role?: 'owner' | 'editor' | 'viewer';
 }
 
 type FilterType = 'all' | 'upcoming' | 'in-progress' | 'completed';
@@ -93,16 +95,73 @@ const TravelPlansList: React.FC = () => {
     }
     try {
       if (initialLoad) setLoading(true);
-      const { data: plansData, error: plansError } = await supabase
+
+      // 1) 내가 소유한 계획
+      const { data: ownerPlans, error: ownerError } = await supabase
         .from('travel_plans')
         .select('id, title, start_date, end_date, location, created_at')
         .eq('owner_id', userProfile.id);
-      if (plansError) {
-        console.error('여행 계획 조회 실패:', plansError);
-        setTravelPlans([]);
-        return;
+      if (ownerError) {
+        console.error('소유 여행 계획 조회 실패:', ownerError);
       }
-      const transformedPlans: TravelPlan[] = (plansData || []).map((plan) => ({
+
+      // 2) 내가 참여(소유자 제외) 중인 계획 id + role
+      const { data: participationRows, error: partError } = await supabase
+        .from('travel_plan_participants')
+        .select('plan_id, role')
+        .eq('user_id', userProfile.id)
+        .neq('role', 'owner');
+      if (partError) {
+        console.error('참여 여행 계획 조회 실패:', partError);
+      }
+
+      const invitedPlanIds = Array.from(
+        new Set((participationRows || []).map((p) => p.plan_id))
+      );
+
+      // 3) 초대(참여) 계획 메타
+      const { data: invitedPlans, error: invitedError } = invitedPlanIds.length
+        ? await supabase
+            .from('travel_plans')
+            .select('id, title, start_date, end_date, location, created_at')
+            .in('id', invitedPlanIds)
+        : { data: [], error: null };
+      if (invitedError) {
+        console.error('초대된 여행 계획 조회 실패:', invitedError);
+      }
+
+      // 4) 참가자 수 집계
+      const allPlanIds = [
+        ...new Set([...(ownerPlans || []).map((p) => p.id), ...invitedPlanIds]),
+      ];
+      const { data: allParticipants, error: participantsError } =
+        allPlanIds.length
+          ? await supabase
+              .from('travel_plan_participants')
+              .select('plan_id')
+              .in('plan_id', allPlanIds)
+          : { data: [], error: null };
+      if (participantsError) {
+        console.warn('참가자 수 조회 경고:', participantsError);
+      }
+      const participantCountMap = new Map<string, number>();
+      (allParticipants || []).forEach((row) => {
+        participantCountMap.set(
+          row.plan_id,
+          (participantCountMap.get(row.plan_id) || 0) + 1
+        );
+      });
+
+      // role 매핑
+      const roleMap = new Map<string, TravelPlan['role']>();
+      (participationRows || []).forEach((r) => {
+        if (!roleMap.has(r.plan_id)) {
+          roleMap.set(r.plan_id, r.role as TravelPlan['role']);
+        }
+      });
+
+      // 5) 변환
+      const ownTransformed: TravelPlan[] = (ownerPlans || []).map((plan) => ({
         id: plan.id,
         title: plan.title,
         start_date: plan.start_date,
@@ -110,10 +169,31 @@ const TravelPlansList: React.FC = () => {
         location: plan.location,
         status: getStatus(plan.start_date, plan.end_date),
         created_at: plan.created_at,
-        participantCount: 1,
+        participantCount: participantCountMap.get(plan.id) || 1,
+        isInvited: false,
+        role: 'owner',
       }));
-      const sortedPlans = sortPlans(transformedPlans, sort);
-      setTravelPlans(sortedPlans);
+
+      const invitedTransformed: TravelPlan[] = (invitedPlans || []).map(
+        (plan) => ({
+          id: plan.id,
+          title: plan.title,
+          start_date: plan.start_date,
+          end_date: plan.end_date,
+          location: plan.location,
+          status: getStatus(plan.start_date, plan.end_date),
+          created_at: plan.created_at,
+          participantCount: participantCountMap.get(plan.id) || 1,
+          isInvited: true,
+          role: roleMap.get(plan.id) || 'viewer',
+        })
+      );
+
+      const merged = sortPlans(
+        [...ownTransformed, ...invitedTransformed],
+        sort
+      );
+      setTravelPlans(merged);
     } catch (error) {
       console.error('여행 계획 조회 중 오류:', error);
       setTravelPlans([]);
@@ -137,6 +217,34 @@ const TravelPlansList: React.FC = () => {
       data.subscription.unsubscribe();
     };
   }, [supabase, fetchTravelPlans]);
+
+  // 참여 테이블 변경 리얼타임 구독: 내 초대 수락 시 자동 갱신
+  useEffect(() => {
+    if (!userProfile?.id) return;
+    const channel = supabase
+      .channel('travel-plan-participants-watch')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'travel_plan_participants',
+          filter: `user_id=eq.${userProfile.id}`,
+        },
+        () => {
+          fetchTravelPlans();
+        }
+      )
+      .subscribe();
+
+    return () => {
+      try {
+        supabase.removeChannel(channel);
+      } catch (error) {
+        console.warn('removeChannel 실패:', error);
+      }
+    };
+  }, [supabase, userProfile?.id, fetchTravelPlans]);
 
   const sortedPlans = useMemo(
     () => sortPlans(travelPlans, sort),
@@ -384,13 +492,20 @@ const TravelPlanCard: React.FC<TravelPlanCardProps> = React.memo(
       >
         <div className='mb-4 flex items-start justify-between'>
           <div className='flex-1'>
-            <Typography
-              variant='h6'
-              weight='semiBold'
-              className='mb-1 text-gray-900'
-            >
-              {plan.title}
-            </Typography>
+            <div className='flex items-center gap-2'>
+              <Typography
+                variant='h6'
+                weight='semiBold'
+                className='mb-1 text-gray-900'
+              >
+                {plan.title}
+              </Typography>
+              {plan.isInvited && (
+                <span className='rounded-full bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-700'>
+                  초대
+                </span>
+              )}
+            </div>
             <Typography variant='body2' className='text-gray-600'>
               {plan.location}
             </Typography>

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -203,9 +203,12 @@ export const useSession = () => {
       return;
     }
 
-    // 세션이 있고 회원가입이 미완료인 경우 sign-up으로 리다이렉트
+    // 세션이 있고 회원가입이 미완료인 경우 sign-up으로 리다이렉트 (현재 경로를 next로 보존)
     if (session && signUpStatus === 'incomplete') {
-      router.push('/sign-up');
+      const safeNext = normalizedPathname.startsWith('/')
+        ? normalizedPathname
+        : '/';
+      router.push(`/sign-up?next=${encodeURIComponent(safeNext)}`);
       return;
     }
   }, [

--- a/apps/web/src/hooks/useTravelPlans.ts
+++ b/apps/web/src/hooks/useTravelPlans.ts
@@ -25,12 +25,37 @@
  *        └── 전체/진행중/완료 필터링, 검색, 정렬
  *
  */
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { createClient } from '@/lib/supabase/client/supabase';
 import type { Activity, TravelPlan } from '@/types/travel';
 
 import { useSession } from './useSession';
+
+export type InvitedTravelPlanItem = {
+  id: string;
+  title: string;
+  location: string;
+  start_date: string;
+  end_date: string;
+  created_at: string;
+  role: 'editor' | 'viewer' | 'owner';
+  participantCount: number;
+};
+
+export type PendingInvitationItem = {
+  id: string; // invitation id
+  plan_id: string;
+  role: 'editor' | 'viewer';
+  created_at: string;
+  plan: {
+    id: string;
+    title: string;
+    location: string;
+    start_date: string;
+    end_date: string;
+  };
+};
 
 export const useUpcomingTravel = () => {
   const { userProfile } = useSession();
@@ -214,4 +239,207 @@ export const useRecentActivities = (limit: number = 10) => {
     },
     enabled: !!userProfile?.id,
   });
+};
+
+export const useInvitedTravelPlans = (limit: number = 5) => {
+  const { userProfile } = useSession();
+  const supabase = createClient();
+
+  return useQuery({
+    queryKey: ['invited-travel-plans', userProfile?.id, limit],
+    queryFn: async (): Promise<InvitedTravelPlanItem[]> => {
+      if (!userProfile?.id) return [];
+
+      // 1) 내가 참여 중이며 소유자가 아닌(plan의 참가자) 레코드 조회
+      const { data: participationRows, error: participationError } =
+        await supabase
+          .from('travel_plan_participants')
+          .select('plan_id, role')
+          .eq('user_id', userProfile.id)
+          .neq('role', 'owner');
+
+      if (participationError) {
+        console.error('Invited plans 참여 조회 오류:', participationError);
+        return [];
+      }
+
+      if (!participationRows || participationRows.length === 0) return [];
+
+      const planIds = Array.from(
+        new Set(participationRows.map((p) => p.plan_id))
+      );
+
+      // 2) 해당 계획들의 메타 정보 조회
+      const { data: plans, error: plansError } = await supabase
+        .from('travel_plans')
+        .select('id, title, location, start_date, end_date, created_at')
+        .in('id', planIds)
+        .order('created_at', { ascending: false })
+        .limit(limit);
+
+      if (plansError) {
+        console.error('Invited plans 메타 조회 오류:', plansError);
+        return [];
+      }
+
+      if (!plans || plans.length === 0) return [];
+
+      // 3) 참가자 수 계산을 위해 동일한 plan_id에 대한 참가자 전체 조회 후 집계
+      const { data: allParticipants, error: allParticipantsError } =
+        await supabase
+          .from('travel_plan_participants')
+          .select('plan_id')
+          .in(
+            'plan_id',
+            plans.map((p) => p.id)
+          );
+
+      if (allParticipantsError) {
+        console.warn('참가자 수 조회 경고:', allParticipantsError);
+      }
+
+      const participantCountMap = new Map<string, number>();
+      (allParticipants || []).forEach((row) => {
+        participantCountMap.set(
+          row.plan_id,
+          (participantCountMap.get(row.plan_id) || 0) + 1
+        );
+      });
+
+      // 사용자 역할 매핑 (plan 별 내 역할)
+      const roleMap = new Map<string, InvitedTravelPlanItem['role']>();
+      participationRows.forEach((r) => {
+        if (!roleMap.has(r.plan_id)) {
+          roleMap.set(r.plan_id, r.role as InvitedTravelPlanItem['role']);
+        }
+      });
+
+      return plans.map((p) => ({
+        id: p.id,
+        title: p.title,
+        location: p.location,
+        start_date: p.start_date,
+        end_date: p.end_date,
+        created_at: p.created_at,
+        role: roleMap.get(p.id) || 'viewer',
+        participantCount: participantCountMap.get(p.id) || 1,
+      }));
+    },
+    enabled: !!userProfile?.id,
+  });
+};
+
+// 초대 대기 목록 조회 (travel_plan_invitations 테이블 가정)
+export const usePendingInvitations = (limit: number = 10) => {
+  const { userProfile } = useSession();
+  const supabase = createClient();
+
+  return useQuery({
+    queryKey: ['pending-invitations', userProfile?.id, limit],
+    queryFn: async (): Promise<PendingInvitationItem[]> => {
+      if (!userProfile?.id) return [];
+
+      // invitations 테이블: id, plan_id, invited_user_id, role, status, created_at
+      const { data, error } = await supabase
+        .from('travel_plan_invitations')
+        .select(
+          'id, plan_id, role, created_at, plan:travel_plans(id, title, location, start_date, end_date)'
+        )
+        .eq('invited_user_id', userProfile.id)
+        .eq('status', 'pending')
+        .order('created_at', { ascending: false })
+        .limit(limit);
+
+      if (error) {
+        console.error('초대 대기목록 조회 오류:', error);
+        return [];
+      }
+
+      // @ts-expect-error: Supabase nested select aliasing
+      return (data || []).map((row) => ({
+        id: row.id,
+        plan_id: row.plan_id,
+        role: row.role,
+        created_at: row.created_at,
+        plan: row.plan,
+      }));
+    },
+    enabled: !!userProfile?.id,
+    retry: 1,
+  });
+};
+
+// 초대 수락/거절 액션과 3개 참여 제한 적용
+export const useInvitationActions = () => {
+  const { userProfile } = useSession();
+  const supabase = createClient();
+  const queryClient = useQueryClient();
+
+  const acceptMutation = useMutation({
+    mutationFn: async (invitationId: string) => {
+      if (!userProfile?.id) throw new Error('인증 필요');
+
+      // 초대 레코드 조회
+      const { data: invitation, error: inviteError } = await supabase
+        .from('travel_plan_invitations')
+        .select('*')
+        .eq('id', invitationId)
+        .eq('status', 'pending')
+        .single();
+      if (inviteError || !invitation)
+        throw inviteError || new Error('초대를 찾을 수 없습니다');
+
+      // 참여 제한 검사 (최대 3개)
+      const { count, error: countError } = await supabase
+        .from('travel_plan_participants')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userProfile.id);
+      if (countError) throw countError;
+      if ((count || 0) >= 3) {
+        throw new Error('여행 참여는 최대 3개까지 가능합니다');
+      }
+
+      // 참가자 추가
+      const { error: insertError } = await supabase
+        .from('travel_plan_participants')
+        .insert({
+          plan_id: invitation.plan_id,
+          user_id: userProfile.id,
+          role: invitation.role ?? 'viewer',
+        });
+      if (insertError) throw insertError;
+
+      // 초대 상태 갱신
+      const { error: updateError } = await supabase
+        .from('travel_plan_invitations')
+        .update({ status: 'accepted' })
+        .eq('id', invitationId);
+      if (updateError) throw updateError;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pending-invitations'] });
+      queryClient.invalidateQueries({ queryKey: ['invited-travel-plans'] });
+    },
+  });
+
+  const declineMutation = useMutation({
+    mutationFn: async (invitationId: string) => {
+      // 초대 상태 거절로 변경
+      const { error } = await supabase
+        .from('travel_plan_invitations')
+        .update({ status: 'declined' })
+        .eq('id', invitationId);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pending-invitations'] });
+    },
+  });
+
+  return {
+    acceptInvitation: acceptMutation.mutateAsync,
+    declineInvitation: declineMutation.mutateAsync,
+    accepting: acceptMutation.isPending,
+    declining: declineMutation.isPending,
+  };
 };

--- a/apps/web/src/hooks/useTravelPlans.ts
+++ b/apps/web/src/hooks/useTravelPlans.ts
@@ -352,9 +352,10 @@ export const useAccessibleTravelPlans = (limit: number = 100) => {
       }));
     },
     enabled: !!userProfile?.id,
-    staleTime: 0,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: 'always',
+    // 최적화: 과도한 refetch 방지 (필요 시 Sidebar에서 refetch 호출)
+    staleTime: 30_000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
   });
 };
 

--- a/apps/web/src/lib/api/invites.ts
+++ b/apps/web/src/lib/api/invites.ts
@@ -1,0 +1,31 @@
+export async function rotateShareLink(
+  planId: string
+): Promise<{ shareLinkId: string }> {
+  const res = await fetch(`/api/travel/${planId}/share-link/rotate`, {
+    method: 'POST',
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to rotate share link');
+  }
+  return (await res.json()) as { shareLinkId: string };
+}
+
+export async function verifyShareLink(shareId: string) {
+  const res = await fetch(`/api/invites/plan/${shareId}`);
+  if (!res.ok) return null;
+  return (await res.json()) as { planId: string; title: string };
+}
+
+export async function acceptShareLink(
+  shareId: string
+): Promise<{ planId: string }> {
+  const res = await fetch(`/api/invites/plan/${shareId}/accept`, {
+    method: 'POST',
+  });
+  if (res.status === 401) throw new Error('UNAUTHORIZED');
+  if (res.status === 409) throw new Error('ALREADY_PARTICIPANT');
+  if (res.status === 422) throw new Error('PARTICIPATION_LIMIT_EXCEEDED');
+  if (!res.ok) throw new Error('FAILED');
+  return (await res.json()) as { planId: string };
+}

--- a/apps/web/src/lib/api/invites.ts
+++ b/apps/web/src/lib/api/invites.ts
@@ -26,6 +26,13 @@ export async function acceptShareLink(
   if (res.status === 401) throw new Error('UNAUTHORIZED');
   if (res.status === 409) throw new Error('ALREADY_PARTICIPANT');
   if (res.status === 422) throw new Error('PARTICIPATION_LIMIT_EXCEEDED');
-  if (!res.ok) throw new Error('FAILED');
+  if (res.status === 410) throw new Error('LINK_EXPIRED');
+  if (res.status === 400) throw new Error('INVALID_REQUEST');
+  if (res.status === 423) throw new Error('LINK_CLOSED');
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}) as any);
+    const detail = (body as any)?.detail as string | undefined;
+    throw new Error(detail ? `FAILED:${detail}` : 'FAILED');
+  }
   return (await res.json()) as { planId: string };
 }

--- a/apps/web/src/lib/supabase/client/supabase-server.ts
+++ b/apps/web/src/lib/supabase/client/supabase-server.ts
@@ -53,5 +53,9 @@ export async function createServerSupabaseClient() {
         }
       },
     },
+    auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+    },
   });
 }

--- a/apps/web/src/lib/supabase/client/supabase.ts
+++ b/apps/web/src/lib/supabase/client/supabase.ts
@@ -1,14 +1,28 @@
 import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 /**
  * 브라우저 환경에서 사용할 Supabase 클라이언트 생성
  * 클라이언트 컴포넌트에서 사용
  */
+let browserSupabaseClient: SupabaseClient | null = null;
+
 export function createClient() {
-  return createBrowserClient(
+  if (browserSupabaseClient) return browserSupabaseClient;
+
+  browserSupabaseClient = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+      },
+    }
   );
+
+  return browserSupabaseClient;
 }
 
 /**


### PR DESCRIPTION
## 📝 설명
초대 링크의 접근 대상(스코프)과 기본 권한을 서버 로직에 연동하고 Sidebar의 무한 렌더링을 제거 및
/log-in·/sign-up의 Suspense 누락으로 인한 빌드 실패를 해결했습니다. 초대 모달 UI/UX도 개선했습니다. 

### 🚀 주요 변경사항
- 초대 링크 권한/스코프 연동
  - `InviteLinkModal.tsx`에서 접근 대상(anyone/owner), 권한 수준(edit/view) 드롭다운 추가
  - 변경 시 즉시 DB 반영: `share_link_scope`, `default_permission(editor|viewer)`
- default_permission에 따라 역할(editor/viewer) 부여
- Sidebar 리렌더링 수정
  - 배열 기본값 이슈 제거, 상태 기반으로 단순화
  - `useMemo`로 변환 및 모바일 오픈 시 `refetch()` 적용
- Auth 빌드 픽스
  - /log-in, /sign-up 페이지: view 컴포넌트를 `<Suspense>`로 감싸 프리렌더 에러 해결