### PR TITLE
feat: 여행 대시보드 및 블록 관리 기능 확장

### DIFF
--- a/apps/storybook/stories/ui/select.stories.tsx
+++ b/apps/storybook/stories/ui/select.stories.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { MultiSelect, Select, type SelectOption } from '@ui/components';
+
+// Select 컴포넌트 스토리
+const selectMeta: Meta<typeof Select> = {
+  title: 'UI/Select',
+  component: Select,
+  args: {
+    label: '통화 선택',
+    options: [
+      { value: 'KRW', label: 'KRW - 원화' },
+      { value: 'USD', label: 'USD - 달러' },
+      { value: 'JPY', label: 'JPY - 엔화' },
+      { value: 'EUR', label: 'EUR - 유로' },
+      { value: 'GBP', label: 'GBP - 파운드' },
+    ] satisfies SelectOption[],
+  },
+};
+
+export default selectMeta;
+type SelectStory = StoryObj<typeof Select>;
+
+export const Basic: SelectStory = {
+  args: {
+    value: 'KRW',
+  },
+};
+
+export const WithPlaceholder: SelectStory = {
+  args: {
+    value: undefined, // value가 없을 때 placeholder가 보입니다.
+    placeholder: '통화를 선택하세요',
+  },
+};
+
+export const Required: SelectStory = {
+  args: {
+    value: undefined,
+    required: true,
+    placeholder: '통화를 선택하세요',
+  },
+};
+
+export const Disabled: SelectStory = {
+  args: {
+    value: 'KRW',
+    disabled: true,
+  },
+};
+
+export const WithError: SelectStory = {
+  args: {
+    value: undefined,
+    error: '통화를 선택해주세요',
+    required: true,
+  },
+};
+
+export const LongOptions: SelectStory = {
+  args: {
+    label: '국가 선택',
+    value: undefined,
+    placeholder: '국가를 선택해주세요',
+    options: [
+      { value: 'KR', label: '대한민국' },
+      { value: 'US', label: '미국' },
+      { value: 'JP', label: '일본' },
+      { value: 'EU', label: '유럽 연합' },
+      { value: 'GB', label: '영국' },
+      { value: 'CN', label: '중국' },
+      { value: 'AU', label: '호주' },
+      { value: 'CA', label: '캐나다' },
+    ] satisfies SelectOption[],
+  },
+};
+
+export const MultiSelectDisableLabelAnimation: StoryObj<typeof MultiSelect> = {
+  render: (args) => {
+    const [value, setValue] = useState<string[]>(['KRW', 'USD']);
+    return (
+      <MultiSelect
+        {...args}
+        label='통화 선택'
+        placeholder='통화를 선택하세요'
+        options={[
+          { value: 'KRW', label: 'KRW - 원화' },
+          { value: 'USD', label: 'USD - 달러' },
+          { value: 'JPY', label: 'JPY - 엔화' },
+        ]}
+        value={value}
+        onChange={setValue}
+        disableLabelAnimation
+      />
+    );
+  },
+};

--- a/apps/web/src/app/(home)/after-login.tsx
+++ b/apps/web/src/app/(home)/after-login.tsx
@@ -18,7 +18,7 @@ const AfterLoginHomeView = () => {
             여행 대시보드
           </Typography>
           <Typography variant='body1' className='text-gray-600'>
-            나의 여행 계획을 한눈에 확인하고 관리해보세요.
+            여행 계획을 한눈에 확인하고 관리해보세요.
           </Typography>
         </div>
 
@@ -33,7 +33,7 @@ const AfterLoginHomeView = () => {
         {/* 여행 계획 목록 */}
         <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
           <Typography
-            variant='h4'
+            variant='h5'
             weight='semiBold'
             className='mb-6 text-gray-900'
           >

--- a/apps/web/src/app/api/blocks/route.ts
+++ b/apps/web/src/app/api/blocks/route.ts
@@ -145,6 +145,7 @@ export async function POST(request: NextRequest) {
       end_time,
       cost,
       currency,
+      meta,
     } = body;
 
     // 필수 필드 검증
@@ -198,6 +199,7 @@ export async function POST(request: NextRequest) {
         location,
         time_range: timeRangeData,
         cost: costData,
+        meta: meta || null,
         created_by: user.id,
       })
       .select()

--- a/apps/web/src/app/api/todos/[id]/route.ts
+++ b/apps/web/src/app/api/todos/[id]/route.ts
@@ -109,7 +109,7 @@ export async function PATCH(
       );
     }
 
-    // 담당자가 변경되는 경우, 해당 사용자가 여행 계획 참여자인지 확인
+    // 담당자가 지정되는 경우 (null이 아닌 경우), 해당 사용자가 여행 계획 참여자인지 확인
     if (body.assigned_user_id !== undefined && body.assigned_user_id !== null) {
       const { data: assigneeParticipant, error: assigneeError } = await supabase
         .from('travel_plan_participants')
@@ -155,7 +155,7 @@ export async function PATCH(
 
       if (userIds.size > 0) {
         const { data: users, error: usersError } = await supabase
-          .from('profiles')
+          .from('user_profiles')
           .select('id, nickname, profile_image_url')
           .in('id', Array.from(userIds));
 

--- a/apps/web/src/app/api/todos/route.ts
+++ b/apps/web/src/app/api/todos/route.ts
@@ -126,7 +126,7 @@ export async function GET(request: Request) {
 
       if (userIds.size > 0) {
         const { data: users, error: usersError } = await supabase
-          .from('profiles')
+          .from('user_profiles')
           .select('id, nickname, profile_image_url')
           .in('id', Array.from(userIds));
 
@@ -265,7 +265,7 @@ export async function POST(request: Request) {
 
       if (userIds.size > 0) {
         const { data: users, error: usersError } = await supabase
-          .from('profiles')
+          .from('user_profiles')
           .select('id, nickname, profile_image_url')
           .in('id', Array.from(userIds));
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import { Analytics } from '@vercel/analytics/next';
 import type { Metadata, Viewport } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
@@ -84,7 +83,6 @@ export default async function RootLayout({
       <body className={pretendard.className}>
         {/* Analytics - 페이지 로드 시 즉시 실행 */}
         <GoogleAnalytics />
-        <Analytics />
 
         {/* App Providers */}
         <NextIntlClientProvider messages={messages}>

--- a/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
+++ b/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
@@ -3,7 +3,7 @@
 import {
   IoAddOutline,
   IoDownloadOutline,
-  IoSettingsOutline,
+  IoPencilOutline,
   IoTimeOutline,
   IoWalletOutline,
 } from 'react-icons/io5';
@@ -18,8 +18,6 @@ import {
 
 import { useBudgetWithExchange } from '@/hooks/useBudgetWithExchange';
 import { usePlanningProgress } from '@/hooks/usePlanningProgress';
-
-// import { calculateDDayWithEnd } from '@/lib/travel-utils';
 
 import { SharedTodoWidget } from './SharedTodoWidget';
 
@@ -64,6 +62,7 @@ interface BriefingBoardProps {
   currency: string;
   destinationCountry?: string; // 목적지 국가 코드
   userNationality?: string; // 사용자 국적
+  isOwner?: boolean; // 현재 사용자가 오너인지 여부
   hotTopics: Array<{
     id: string;
     title: string;
@@ -89,6 +88,7 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
   currency,
   destinationCountry,
   userNationality,
+  isOwner = false,
   onInviteParticipants,
   onExport,
   onSettings,
@@ -177,58 +177,62 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
               </div>
             </div>
 
-            {/* 빠른 액션 */}
-            <div className='w-full rounded-xl bg-white p-3 shadow-sm sm:rounded-2xl sm:p-4 md:p-5 lg:p-6'>
-              <Typography
-                variant='h6'
-                className='mb-3 font-semibold text-gray-900 sm:mb-4'
-              >
-                빠른 액션
-              </Typography>
-              <div className='grid w-full grid-cols-1 gap-2 sm:gap-3'>
-                <Button
-                  onClick={onInviteParticipants}
-                  colorTheme='blue'
-                  size='medium'
-                  className='h-10 w-full justify-start rounded-lg shadow-sm transition-all duration-200 hover:shadow-md sm:h-11 sm:rounded-xl md:h-12 lg:h-14'
-                  leftIcon={<IoAddOutline className='h-4 w-4 sm:h-5 sm:w-5' />}
+            {/* 빠른 액션 - 오너만 표시 */}
+            {isOwner && (
+              <div className='w-full rounded-xl bg-white p-3 shadow-sm sm:rounded-2xl sm:p-4 md:p-5 lg:p-6'>
+                <Typography
+                  variant='h6'
+                  className='mb-3 font-semibold text-gray-900 sm:mb-4'
                 >
-                  <div className='ml-2 text-left sm:ml-3'>
-                    <Typography variant='h6' className='text-white'>
-                      동반자 초대하기
-                    </Typography>
+                  빠른 액션
+                </Typography>
+                <div className='grid w-full grid-cols-1 gap-2 sm:gap-3'>
+                  <Button
+                    onClick={onInviteParticipants}
+                    colorTheme='blue'
+                    size='medium'
+                    className='h-10 w-full justify-start rounded-lg shadow-sm transition-all duration-200 hover:shadow-md sm:h-11 sm:rounded-xl md:h-12 lg:h-14'
+                    leftIcon={
+                      <IoAddOutline className='h-4 w-4 sm:h-5 sm:w-5' />
+                    }
+                  >
+                    <div className='ml-2 text-left sm:ml-3'>
+                      <Typography variant='h6' className='text-white'>
+                        동반자 초대하기
+                      </Typography>
+                    </div>
+                  </Button>
+                  <div className='grid w-full grid-cols-2 gap-2 sm:gap-3'>
+                    <Button
+                      onClick={onExport}
+                      colorTheme='gray'
+                      size='medium'
+                      className='h-9 w-full justify-start rounded-lg shadow-sm transition-all duration-200 hover:shadow-md sm:h-10 sm:rounded-xl md:h-11'
+                      leftIcon={
+                        <IoDownloadOutline className='h-3 w-3 sm:h-4 sm:w-4' />
+                      }
+                    >
+                      <span className='ml-1 text-xs sm:ml-2 sm:text-sm'>
+                        내보내기
+                      </span>
+                    </Button>
+                    <Button
+                      onClick={onSettings}
+                      colorTheme='gray'
+                      size='medium'
+                      className='h-9 w-full justify-start rounded-lg shadow-sm transition-all duration-200 hover:shadow-md sm:h-10 sm:rounded-xl md:h-11'
+                      leftIcon={
+                        <IoPencilOutline className='h-3 w-3 sm:h-4 sm:w-4' />
+                      }
+                    >
+                      <span className='ml-1 text-xs sm:ml-2 sm:text-sm'>
+                        여행 정보 수정
+                      </span>
+                    </Button>
                   </div>
-                </Button>
-                <div className='grid w-full grid-cols-2 gap-2 sm:gap-3'>
-                  <Button
-                    onClick={onExport}
-                    colorTheme='gray'
-                    size='medium'
-                    className='h-9 w-full justify-start rounded-lg shadow-sm transition-all duration-200 hover:shadow-md sm:h-10 sm:rounded-xl md:h-11'
-                    leftIcon={
-                      <IoDownloadOutline className='h-3 w-3 sm:h-4 sm:w-4' />
-                    }
-                  >
-                    <span className='ml-1 text-xs sm:ml-2 sm:text-sm'>
-                      내보내기
-                    </span>
-                  </Button>
-                  <Button
-                    onClick={onSettings}
-                    colorTheme='gray'
-                    size='medium'
-                    className='h-9 w-full justify-start rounded-lg shadow-sm transition-all duration-200 hover:shadow-md sm:h-10 sm:rounded-xl md:h-11'
-                    leftIcon={
-                      <IoSettingsOutline className='h-3 w-3 sm:h-4 sm:w-4' />
-                    }
-                  >
-                    <span className='ml-1 text-xs sm:ml-2 sm:text-sm'>
-                      설정
-                    </span>
-                  </Button>
                 </div>
               </div>
-            </div>
+            )}
 
             {/* 최근 변경사항 */}
             <div className='w-full rounded-xl bg-white p-3 shadow-sm sm:rounded-2xl sm:p-4 md:p-5 lg:p-6'>

--- a/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
+++ b/apps/web/src/app/travel/[id]/components/BriefingBoard.tsx
@@ -2,6 +2,7 @@
 
 import {
   IoAddOutline,
+  IoChevronForwardOutline,
   IoDownloadOutline,
   IoPencilOutline,
   IoTimeOutline,
@@ -76,6 +77,7 @@ interface BriefingBoardProps {
   onHotTopicClick: (blockId: string) => void;
   onBudgetClick?: () => void;
   onReadinessClick?: () => void;
+  onViewAllActivities?: () => void;
 }
 
 export const BriefingBoard: React.FC<BriefingBoardProps> = ({
@@ -94,6 +96,8 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
   onSettings,
   onBudgetClick,
   onReadinessClick,
+  onViewAllActivities,
+  onBlockClick,
 }) => {
   // 여행 계획율 계산
   const {
@@ -236,17 +240,40 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
 
             {/* 최근 변경사항 */}
             <div className='w-full rounded-xl bg-white p-3 shadow-sm sm:rounded-2xl sm:p-4 md:p-5 lg:p-6'>
-              <Typography
-                variant='h6'
-                className='mb-3 font-semibold text-gray-900 sm:mb-4'
-              >
-                최근 변경사항
-              </Typography>
+              <div className='mb-3 flex items-center justify-between sm:mb-4'>
+                <Typography
+                  variant='h6'
+                  className='font-semibold text-gray-900'
+                >
+                  최근 변경사항
+                </Typography>
+                {activities.length > 3 && (
+                  <Button
+                    onClick={onViewAllActivities}
+                    variant='outlined'
+                    colorTheme='gray'
+                    size='small'
+                    className='h-8 px-3'
+                    rightIcon={<IoChevronForwardOutline className='h-3 w-3' />}
+                  >
+                    <span className='text-xs'>더 보기</span>
+                  </Button>
+                )}
+              </div>
               <div className='space-y-2 sm:space-y-3'>
-                {activities.map((activity: ActivityItem) => (
+                {activities.slice(0, 3).map((activity: ActivityItem) => (
                   <div
                     key={activity.id}
-                    className='rounded-lg border border-gray-200 p-3'
+                    className={`rounded-lg border border-gray-200 p-3 ${
+                      activity.blockId
+                        ? 'cursor-pointer transition-all duration-200 hover:border-blue-300 hover:bg-blue-50'
+                        : ''
+                    }`}
+                    onClick={() => {
+                      if (activity.blockId) {
+                        onBlockClick(activity.blockId);
+                      }
+                    }}
                   >
                     <div className='flex items-start space-x-3'>
                       <Avatar
@@ -270,13 +297,28 @@ export const BriefingBoard: React.FC<BriefingBoardProps> = ({
                             variant='caption'
                             className='text-gray-400'
                           >
-                            {activity.timestamp}
+                            {new Date(activity.timestamp).toLocaleString(
+                              'ko-KR',
+                              {
+                                month: 'short',
+                                day: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit',
+                              }
+                            )}
                           </Typography>
                         </div>
                       </div>
                     </div>
                   </div>
                 ))}
+                {activities.length === 0 && (
+                  <div className='py-8 text-center'>
+                    <Typography variant='body2' className='text-gray-500'>
+                      아직 활동 내역이 없습니다.
+                    </Typography>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/apps/web/src/app/travel/[id]/components/DayTab.tsx
+++ b/apps/web/src/app/travel/[id]/components/DayTab.tsx
@@ -81,23 +81,25 @@ export const DayTab = forwardRef<HTMLButtonElement, DayTabProps>(
           >
             Day {tab.dayNumber}
           </Typography>
-          {tab.date && (
-            <Typography variant='caption' className='text-xs text-gray-500'>
-              {new Date(tab.date).toLocaleDateString('ko-KR', {
-                month: 'short',
-                day: 'numeric',
-              })}
-            </Typography>
-          )}
-          {tab.totalCost && tab.totalCost.amount > 0 ? (
-            <Typography variant='caption' className='text-xs text-gray-400'>
-              {formatCurrency(
-                tab.totalCost.amount,
-                (tab.totalCost.currency as CurrencyCode) || 'KRW'
+          {(tab.date || (tab.totalCost && tab.totalCost.amount > 0)) && (
+            <div className='flex flex-col items-center'>
+              {tab.date && (
+                <Typography variant='caption' className='text-xs text-gray-500'>
+                  {new Date(tab.date).toLocaleDateString('ko-KR', {
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </Typography>
               )}
-            </Typography>
-          ) : (
-            <div className='h-3'></div> // 비용이 없을 때도 공간 확보
+              {tab.totalCost && tab.totalCost.amount > 0 && (
+                <Typography variant='caption' className='text-xs text-gray-400'>
+                  {formatCurrency(
+                    tab.totalCost.amount,
+                    (tab.totalCost.currency as CurrencyCode) || 'KRW'
+                  )}
+                </Typography>
+              )}
+            </div>
           )}
         </div>
       );

--- a/apps/web/src/app/travel/[id]/view.tsx
+++ b/apps/web/src/app/travel/[id]/view.tsx
@@ -463,6 +463,7 @@ const TravelDetailView = () => {
                 endDate={travelPlan.end_date}
                 participants={(participants as ApiParticipant[]).map((p) => ({
                   id: p.id,
+                  user_id: p.user_id,
                   nickname: p.nickname || '알 수 없음',
                   profile_image_url: p.profile_image_url,
                   isOnline: p.isOnline || false,

--- a/apps/web/src/app/travel/[id]/view.tsx
+++ b/apps/web/src/app/travel/[id]/view.tsx
@@ -13,6 +13,7 @@ import { BlockCreateModal } from '@/components/travel/detail/BlockCreateModal';
 import { BlockDetailModal } from '@/components/travel/detail/BlockDetailModal';
 import { TravelTimelineCanvas } from '@/components/travel/detail/TravelTimelineCanvas';
 import InviteLinkModal from '@/components/travel/modals/InviteLinkModal';
+import TravelEditInfoModal from '@/components/travel/modals/TravelEditInfoModal';
 import { useParticipantsPresence } from '@/hooks/useParticipantsPresence';
 import { useRealtimeBlocks } from '@/hooks/useRealtimeBlocks';
 import { useRealtimeParticipants } from '@/hooks/useRealtimeParticipants';
@@ -55,6 +56,7 @@ const TravelDetailView = () => {
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
+  const [showEditInfoModal, setShowEditInfoModal] = useState(false);
   const [selectedBlock, setSelectedBlock] = useState<TravelBlock | null>(null);
   const [editingBlock, setEditingBlock] = useState<TravelBlock | null>(null);
   const [selectedDay, setSelectedDay] = useState<number>(0); // 0은 대시보드
@@ -326,7 +328,7 @@ const TravelDetailView = () => {
   };
 
   const handleSettings = () => {
-    toast('설정 기능은 준비 중입니다.');
+    setShowEditInfoModal(true);
   };
 
   const handleBudgetClick = () => {
@@ -491,6 +493,7 @@ const TravelDetailView = () => {
                   )?.destination_country
                 }
                 userNationality={userProfile?.nationality}
+                isOwner={isOwner}
                 hotTopics={hotTopics}
                 onInviteParticipants={handleInviteParticipants}
                 onExport={handleExport}
@@ -594,6 +597,18 @@ const TravelDetailView = () => {
           }
           participants={participants}
           isOwner={isOwner}
+        />
+      )}
+
+      {showEditInfoModal && (
+        <TravelEditInfoModal
+          isOpen={showEditInfoModal}
+          onClose={() => setShowEditInfoModal(false)}
+          travelPlan={travelPlan}
+          onUpdate={() => {
+            // 여행 정보 업데이트 후 데이터 새로고침
+            // useTravelDetail 훅이 자동으로 refetch할 것입니다
+          }}
         />
       )}
     </div>

--- a/apps/web/src/app/travel/[id]/view.tsx
+++ b/apps/web/src/app/travel/[id]/view.tsx
@@ -13,6 +13,7 @@ import { BlockCreateModal } from '@/components/travel/detail/BlockCreateModal';
 import { BlockDetailModal } from '@/components/travel/detail/BlockDetailModal';
 import { TravelTimelineCanvas } from '@/components/travel/detail/TravelTimelineCanvas';
 import InviteLinkModal from '@/components/travel/modals/InviteLinkModal';
+import TravelActivitiesModal from '@/components/travel/modals/TravelActivitiesModal';
 import TravelEditInfoModal from '@/components/travel/modals/TravelEditInfoModal';
 import { useParticipantsPresence } from '@/hooks/useParticipantsPresence';
 import { useRealtimeBlocks } from '@/hooks/useRealtimeBlocks';
@@ -57,6 +58,7 @@ const TravelDetailView = () => {
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showEditInfoModal, setShowEditInfoModal] = useState(false);
+  const [showActivitiesModal, setShowActivitiesModal] = useState(false);
   const [selectedBlock, setSelectedBlock] = useState<TravelBlock | null>(null);
   const [editingBlock, setEditingBlock] = useState<TravelBlock | null>(null);
   const [selectedDay, setSelectedDay] = useState<number>(0); // 0은 대시보드
@@ -331,6 +333,10 @@ const TravelDetailView = () => {
     setShowEditInfoModal(true);
   };
 
+  const handleViewAllActivities = () => {
+    setShowActivitiesModal(true);
+  };
+
   const handleBudgetClick = () => {
     // TODO: 예산 상세 모달 또는 페이지로 이동
     console.log('Budget detail clicked');
@@ -342,8 +348,22 @@ const TravelDetailView = () => {
   };
 
   const handleBlockClick = (blockId: string) => {
-    // TODO: 새로운 API 데이터와 기존 TravelBlock 타입 매핑 필요
-    console.log('Block click:', blockId);
+    // 해당 블록 찾기
+    const apiBlock = blocks.find((block) => block.id === blockId);
+    if (!apiBlock) {
+      toast.error('블록을 찾을 수 없습니다.');
+      return;
+    }
+
+    // 해당 블록이 있는 날짜로 탭 전환
+    setSelectedDay(apiBlock.day_number);
+
+    // API 블록을 TravelBlock 타입으로 변환
+    const travelBlock = convertApiBlockToTravelBlock(apiBlock);
+
+    // 블록 상세 모달 열기
+    setSelectedBlock(travelBlock);
+    setShowDetailModal(true);
   };
 
   const handleHotTopicClick = (blockId: string) => {
@@ -502,6 +522,7 @@ const TravelDetailView = () => {
                 onReadinessClick={handleReadinessClick}
                 onBlockClick={handleBlockClick}
                 onHotTopicClick={handleHotTopicClick}
+                onViewAllActivities={handleViewAllActivities}
               />
             </div>
           ) : (
@@ -609,6 +630,16 @@ const TravelDetailView = () => {
             // 여행 정보 업데이트 후 데이터 새로고침
             // useTravelDetail 훅이 자동으로 refetch할 것입니다
           }}
+        />
+      )}
+
+      {showActivitiesModal && (
+        <TravelActivitiesModal
+          isOpen={showActivitiesModal}
+          onClose={() => setShowActivitiesModal(false)}
+          activities={activities}
+          travelTitle={travelPlan.title}
+          onBlockClick={handleBlockClick}
         />
       )}
     </div>

--- a/apps/web/src/components/basic/Modal/Modal.tsx
+++ b/apps/web/src/components/basic/Modal/Modal.tsx
@@ -32,6 +32,7 @@ export interface ModalProps {
   onSecondaryAction?: () => void;
   children?: React.ReactNode;
   width?: 'sm' | 'md' | 'lg' | 'xl' | 'full' | 'responsive';
+  showCloseButton?: boolean;
 }
 
 const modalVariants: Variants = {
@@ -88,6 +89,7 @@ export const Modal = ({
   onSecondaryAction,
   children,
   width = 'md',
+  showCloseButton = true,
 }: ModalProps) => {
   const [isMounted, setIsMounted] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -394,16 +396,18 @@ export const Modal = ({
               aria-modal='true'
               aria-labelledby='modal-title'
             >
-              <div className='absolute right-4 top-4 z-10'>
-                <Button
-                  variant='text'
-                  size='small'
-                  onClick={onClose}
-                  aria-label='닫기'
-                >
-                  <IoCloseOutline className='h-5 w-5 text-gray-500' />
-                </Button>
-              </div>
+              {showCloseButton && (
+                <div className='absolute right-4 top-4 z-10'>
+                  <Button
+                    variant='text'
+                    size='small'
+                    onClick={onClose}
+                    aria-label='닫기'
+                  >
+                    <IoCloseOutline className='h-5 w-5 text-gray-500' />
+                  </Button>
+                </div>
+              )}
               {renderModalContent()}
             </motion.div>
           </motion.div>

--- a/apps/web/src/components/layout/Header/Header.tsx
+++ b/apps/web/src/components/layout/Header/Header.tsx
@@ -345,14 +345,14 @@ export const Header = ({
                 </Typography>
               </div>
 
-              <Link
+              {/* <Link
                 href='/profile'
                 className='flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100'
                 onClick={() => setProfileDropdownOpen(false)}
               >
-                <Icon as={CiUser} className='mr-2 h-4 w-4' />
+                <Icon as={CiUser} className='w-4 h-4 mr-2' />
                 프로필 설정
-              </Link>
+              </Link> */}
 
               <button
                 onClick={handleSignOut}
@@ -452,13 +452,13 @@ export const Header = ({
           </div>
 
           {/* 프로필 설정 버튼 */}
-          <Link
+          {/* <Link
             href='/profile'
-            className='flex w-full items-center justify-center rounded-xl bg-gray-100 px-4 py-3 font-medium text-gray-700 transition-colors hover:bg-gray-200'
+            className='flex items-center justify-center w-full px-4 py-3 font-medium text-gray-700 transition-colors bg-gray-100 rounded-xl hover:bg-gray-200'
             onClick={() => setMobileMenuOpen(false)}
           >
             프로필 설정
-          </Link>
+          </Link> */}
 
           {/* 로그아웃 버튼 */}
           <button

--- a/apps/web/src/components/layout/Header/Header.tsx
+++ b/apps/web/src/components/layout/Header/Header.tsx
@@ -302,15 +302,15 @@ export const Header = ({
       </Button>
 
       {/* 알림 아이콘 */}
-      <button
-        className='flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-gray-100'
+      {/* <button
+        className='flex items-center justify-center w-10 h-10 transition-colors rounded-full hover:bg-gray-100'
         onClick={() => {
           // TODO: 알림 모달 열기
           console.log('알림 모달 열기');
         }}
       >
         <Icon as={IoNotificationsOutline} color='#374151' size={24} />
-      </button>
+      </button> */}
 
       {/* 아바타 */}
       <div className='profile-dropdown relative'>
@@ -422,8 +422,8 @@ export const Header = ({
           </button>
 
           {/* 알림 버튼 */}
-          <button
-            className='flex w-full items-center justify-center space-x-2 rounded-xl bg-gray-100 px-4 py-3 font-medium text-gray-700 transition-colors hover:bg-gray-200'
+          {/* <button
+            className='flex items-center justify-center w-full px-4 py-3 space-x-2 font-medium text-gray-700 transition-colors bg-gray-100 rounded-xl hover:bg-gray-200'
             onClick={() => {
               // TODO: 알림 모달 열기
               console.log('알림 모달 열기');
@@ -432,7 +432,7 @@ export const Header = ({
           >
             <Icon as={IoNotificationsOutline} size={20} />
             <span>알림</span>
-          </button>
+          </button> */}
 
           {/* 사용자 프로필 정보 */}
           <div className='flex items-center space-x-3 px-4 py-2'>
@@ -531,9 +531,9 @@ export const Header = ({
         </button>
 
         {/* 알림 버튼 */}
-        <button className='rounded-full p-2 text-gray-700 transition-colors hover:bg-gray-100'>
-          <IoNotificationsOutline className='h-5 w-5' />
-        </button>
+        {/* <button className='p-2 text-gray-700 transition-colors rounded-full hover:bg-gray-100'>
+          <IoNotificationsOutline className='w-5 h-5' />
+        </button> */}
 
         {/* 프로필 영역 */}
         {renderProfileArea()}

--- a/apps/web/src/components/travel/detail/BlockCreateModal.tsx
+++ b/apps/web/src/components/travel/detail/BlockCreateModal.tsx
@@ -1,33 +1,25 @@
-/*
-  BlockCreateModal.tsx
-  - 새 일정(블록) 생성 모달 컴포넌트
-  - 공통 필드(제목/설명/위치/시간/비용) + 타입별 필드(항공/이동/숙소/식사/액티비티)를 렌더링
-  - 제출 시 CreateBlockRequest를 구성하여 상위(onCreateBlock)로 전달
-  - SSR 환경에서도 안전하게 동작하도록 createPortal 사용
-*/
 import React, { useEffect, useState } from 'react';
 
-import { createPortal } from 'react-dom';
+import { motion } from 'framer-motion';
 import {
-  IoAirplaneOutline,
-  IoBedOutline,
-  IoCarOutline,
-  IoCloseOutline,
-  IoDocumentTextOutline,
-  IoGameControllerOutline,
-  IoRestaurantOutline,
+  IoCheckmarkOutline,
+  IoInformationCircleOutline,
 } from 'react-icons/io5';
 
 import { Button, Typography } from '@ui/components';
 
+import { Modal } from '@/components/basic/Modal';
 import {
-  CURRENCIES,
-  CurrencyCode,
-  formatCurrencyInput,
-  getCurrencyFromLocation,
-  parseCurrencyInput,
-} from '@/lib/currency';
+  blockTypeConfigs,
+  getArrivalAirportSuggestions,
+  getDefaultCurrencyForBlock,
+  getDefaultDuration,
+  getDepartureAirportSuggestions,
+} from '@/lib/block-helpers';
+import { CurrencyCode, parseCurrencyInput } from '@/lib/currency';
 import { BlockType, CreateBlockRequest } from '@/types/travel/blocks';
+
+import { SmartBudgetInput, SmartInput, SmartTimeInput } from './SmartInputs';
 
 interface BlockCreateModalProps {
   isOpen: boolean;
@@ -37,6 +29,8 @@ interface BlockCreateModalProps {
   onCreateBlock: (request: CreateBlockRequest) => void;
   isLoading: boolean;
   planLocation: string;
+  userNationality?: string;
+  totalBudget?: number;
 }
 
 export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
@@ -47,6 +41,8 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
   onCreateBlock,
   isLoading,
   planLocation,
+  userNationality = 'KR',
+  totalBudget = 0,
 }) => {
   // 기본 필드 상태 관리
   const [selectedType, setSelectedType] = useState<BlockType>('activity');
@@ -74,55 +70,23 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
   const [activityType, setActivityType] = useState('');
   const [reservationRequired, setReservationRequired] = useState(false);
 
-  // 여행지 위치에 따라 기본 통화 자동 설정
+  // 블록 타입 변경 시 스마트 통화 설정
   useEffect(() => {
-    if (planLocation) {
-      const detectedCurrency = getCurrencyFromLocation(planLocation);
-      setCurrency(detectedCurrency);
-    }
-  }, [planLocation]);
+    const defaultCurrency = getDefaultCurrencyForBlock(
+      selectedType,
+      userNationality,
+      planLocation
+    );
+    setCurrency(defaultCurrency);
+  }, [selectedType, userNationality, planLocation]);
 
-  // 블록 타입별 설정 정보 (아이콘, 색상, 라벨)
-  const blockTypes = [
-    {
-      type: 'flight' as BlockType,
-      label: '항공',
-      icon: <IoAirplaneOutline className='h-6 w-6' />,
-      color: 'text-sky-500',
-    },
-    {
-      type: 'move' as BlockType,
-      label: '이동',
-      icon: <IoCarOutline className='h-6 w-6' />,
-      color: 'text-blue-500',
-    },
-    {
-      type: 'food' as BlockType,
-      label: '식사',
-      icon: <IoRestaurantOutline className='h-6 w-6' />,
-      color: 'text-orange-500',
-    },
-    {
-      type: 'hotel' as BlockType,
-      label: '숙소',
-      icon: <IoBedOutline className='h-6 w-6' />,
-      color: 'text-purple-500',
-    },
-    {
-      type: 'activity' as BlockType,
-      label: '관광/액티비티',
-      icon: <IoGameControllerOutline className='h-6 w-6' />,
-      color: 'text-green-500',
-    },
-    {
-      type: 'memo' as BlockType,
-      label: '메모',
-      icon: <IoDocumentTextOutline className='h-6 w-6' />,
-      color: 'text-gray-500',
-    },
-  ];
+  // 현재 선택된 블록 타입 설정
+  const currentBlockConfig = blockTypeConfigs.find(
+    (config) => config.type === selectedType
+  );
+  const suggestedDuration = getDefaultDuration(selectedType);
 
-  // 폼 제출 처리: 블록 타입별 메타데이터 구성 및 API 요청
+  // 폼 제출 처리
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
@@ -132,62 +96,50 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
 
     switch (selectedType) {
       case 'flight':
-        // 항공 블록: 항공편 정보, 공항 정보, 좌석 정보
-        meta.flightNumber = flightNumber;
-        meta.departureAirport = departureAirport;
-        meta.arrivalAirport = arrivalAirport;
-        meta.seatNumber = seatNumber;
+        if (flightNumber) meta.flightNumber = flightNumber;
+        if (departureAirport) meta.departureAirport = departureAirport;
+        if (arrivalAirport) meta.arrivalAirport = arrivalAirport;
+        if (seatNumber) meta.seatNumber = seatNumber;
         break;
       case 'move':
-        // 이동 블록: 교통수단, 출발지/도착지 정보
-        meta.transportType = transportType;
-        meta.fromLocation = fromLocation
-          ? { address: fromLocation }
-          : undefined;
-        meta.toLocation = toLocation ? { address: toLocation } : undefined;
+        if (transportType) meta.transportType = transportType;
+        if (fromLocation) meta.fromLocation = { address: fromLocation };
+        if (toLocation) meta.toLocation = { address: toLocation };
         break;
       case 'hotel':
-        // 숙소 블록: 체크인/아웃, 객실 타입
-        meta.checkIn = checkIn;
-        meta.checkOut = checkOut;
-        meta.roomType = roomType;
+        if (checkIn) meta.checkIn = checkIn;
+        if (checkOut) meta.checkOut = checkOut;
+        if (roomType) meta.roomType = roomType;
         break;
       case 'food':
-        // 식사 블록: 식사 종류, 요리 종류
-        meta.mealType = mealType;
-        meta.cuisine = cuisine;
+        if (mealType) meta.mealType = mealType;
+        if (cuisine) meta.cuisine = cuisine;
         break;
       case 'activity':
-        // 액티비티 블록: 액티비티 종류, 예약 필요 여부
-        meta.activityType = activityType;
+        if (activityType) meta.activityType = activityType;
         meta.reservationRequired = reservationRequired;
         break;
     }
 
-    // CreateBlockRequest 객체 구성
     const request: CreateBlockRequest = {
       planId,
       dayNumber,
       blockType: selectedType,
       title: title.trim(),
       description: description.trim() || undefined,
-      // 위치 정보가 있는 경우 Location 객체로 변환
       location: address.trim() ? { address: address.trim() } : undefined,
-      // 시간 정보가 있는 경우 TimeRange 객체로 변환
       timeRange: startTime
         ? {
             startTime,
             endTime: endTime || undefined,
           }
         : undefined,
-      // 비용 정보가 있는 경우 Cost 객체로 변환 (문자열을 숫자로 파싱)
       cost: amount
         ? {
             amount: parseCurrencyInput(amount),
             currency: currency,
           }
         : undefined,
-      // 메타데이터가 있는 경우에만 포함
       meta: Object.keys(meta).length > 0 ? meta : undefined,
     };
 
@@ -221,230 +173,290 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
     onClose();
   };
 
+  // 블록 타입 선택 UI 렌더링
+  const renderBlockTypeSelection = () => (
+    <div className='border-b border-gray-100 p-3 pb-6'>
+      <Typography variant='h5' className='mb-2 font-bold text-gray-900'>
+        {currentBlockConfig?.icon} 새로운 일정 추가
+      </Typography>
+      <Typography variant='body2' className='mb-6 text-gray-500'>
+        Day {dayNumber} • 완벽한 여행을 위한 한 걸음
+      </Typography>
+
+      <Typography variant='body1' className='mb-4 font-semibold text-gray-800'>
+        일정 유형을 선택하세요
+      </Typography>
+
+      <div className='grid grid-cols-2 gap-3 sm:grid-cols-3'>
+        {blockTypeConfigs.map((blockType) => (
+          <motion.button
+            key={blockType.type}
+            type='button'
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={() => setSelectedType(blockType.type)}
+            className={`relative overflow-hidden rounded-2xl p-4 text-left transition-all ${
+              selectedType === blockType.type
+                ? 'shadow-lg ring-2 ring-blue-500 ring-offset-2'
+                : 'border border-gray-200 hover:shadow-md'
+            }`}
+          >
+            {/* 그라데이션 배경 */}
+            <div
+              className={`absolute inset-0 bg-gradient-to-br ${blockType.gradient} opacity-10`}
+            />
+
+            {/* 콘텐츠 */}
+            <div className='relative'>
+              <div className='mb-2 text-2xl'>{blockType.icon}</div>
+              <Typography
+                variant='body2'
+                className='mb-1 font-semibold text-gray-900'
+              >
+                {blockType.label}
+              </Typography>
+              <Typography variant='caption' className='text-gray-500'>
+                {blockType.description}
+              </Typography>
+            </div>
+
+            {/* 선택 표시 */}
+            {selectedType === blockType.type && (
+              <motion.div
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                className='absolute right-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-blue-500'
+              >
+                <IoCheckmarkOutline className='h-4 w-4 text-white' />
+              </motion.div>
+            )}
+          </motion.button>
+        ))}
+      </div>
+    </div>
+  );
+
   // 블록 타입별 전용 입력 필드 렌더링
   const renderTypeSpecificFields = () => {
     switch (selectedType) {
       case 'flight':
         return (
-          <div className='space-y-4'>
+          <div className='space-y-6'>
+            {/* 항공료 통화 안내 */}
+            {selectedType === 'flight' && (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className='flex items-center space-x-3 rounded-2xl bg-blue-50 p-4'
+              >
+                <div className='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-100'>
+                  <IoInformationCircleOutline className='h-4 w-4 text-blue-600' />
+                </div>
+                <div className='flex-1'>
+                  <Typography
+                    variant='body2'
+                    className='font-medium text-blue-900'
+                  >
+                    항공료는 출발국 통화로 결제됩니다
+                  </Typography>
+                  <Typography variant='caption' className='text-blue-600'>
+                    {userNationality === 'KR' ? '한국' : userNationality}에서
+                    출발하므로 {currency}로 설정됩니다.
+                  </Typography>
+                </div>
+              </motion.div>
+            )}
+
             <div className='grid grid-cols-2 gap-4'>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  항공편명
-                </label>
-                <input
-                  type='text'
-                  value={flightNumber}
-                  onChange={(e) => setFlightNumber(e.target.value)}
-                  placeholder='예: KE123'
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  좌석번호
-                </label>
-                <input
-                  type='text'
-                  value={seatNumber}
-                  onChange={(e) => setSeatNumber(e.target.value)}
-                  placeholder='예: 12A'
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
+              <SmartInput
+                label='항공편명'
+                value={flightNumber}
+                onChange={setFlightNumber}
+                placeholder='예: KE123'
+                disableLabelAnimation={true}
+              />
+              <SmartInput
+                label='좌석번호'
+                value={seatNumber}
+                onChange={setSeatNumber}
+                placeholder='예: 12A'
+                disableLabelAnimation={true}
+              />
             </div>
+
             <div className='grid grid-cols-2 gap-4'>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  출발공항
-                </label>
-                <input
-                  type='text'
-                  value={departureAirport}
-                  onChange={(e) => setDepartureAirport(e.target.value)}
-                  placeholder='예: 인천국제공항'
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  도착공항
-                </label>
-                <input
-                  type='text'
-                  value={arrivalAirport}
-                  onChange={(e) => setArrivalAirport(e.target.value)}
-                  placeholder='예: 나리타공항'
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
+              <SmartInput
+                label='출발공항'
+                value={departureAirport}
+                onChange={setDepartureAirport}
+                placeholder='공항을 선택하세요'
+                suggestions={getDepartureAirportSuggestions(userNationality)}
+                disableLabelAnimation={true}
+              />
+              <SmartInput
+                label='도착공항'
+                value={arrivalAirport}
+                onChange={setArrivalAirport}
+                placeholder='공항을 선택하세요'
+                suggestions={getArrivalAirportSuggestions(planLocation)}
+                disableLabelAnimation={true}
+              />
             </div>
           </div>
         );
 
       case 'move':
         return (
-          <div className='space-y-4'>
-            <div>
-              <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                교통수단
-              </label>
+          <div className='space-y-6'>
+            <div className='relative'>
               <select
                 value={transportType}
                 onChange={(e) => setTransportType(e.target.value)}
-                className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
+                className='w-full rounded-2xl border-2 border-gray-200 bg-gray-50/50 px-4 py-4 pb-2 pt-6 text-gray-900 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0'
               >
                 <option value=''>선택하세요</option>
-                <option value='walk'>도보</option>
-                <option value='car'>자동차</option>
-                <option value='bus'>버스</option>
-                <option value='subway'>지하철</option>
-                <option value='taxi'>택시</option>
-                <option value='train'>기차</option>
+                <option value='walk'>🚶 도보</option>
+                <option value='car'>🚗 자동차</option>
+                <option value='bus'>🚌 버스</option>
+                <option value='subway'>🚇 지하철</option>
+                <option value='taxi'>🚕 택시</option>
+                <option value='train'>🚄 기차</option>
               </select>
+              <label className='absolute left-4 top-2 text-xs font-medium text-gray-500'>
+                교통수단
+              </label>
             </div>
+
             <div className='grid grid-cols-2 gap-4'>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  출발지
-                </label>
-                <input
-                  type='text'
-                  value={fromLocation}
-                  onChange={(e) => setFromLocation(e.target.value)}
-                  placeholder='출발 위치'
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  도착지
-                </label>
-                <input
-                  type='text'
-                  value={toLocation}
-                  onChange={(e) => setToLocation(e.target.value)}
-                  placeholder='도착 위치'
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
+              <SmartInput
+                label='출발지'
+                value={fromLocation}
+                onChange={setFromLocation}
+                placeholder='출발 위치를 입력하세요'
+                disableLabelAnimation={true}
+              />
+              <SmartInput
+                label='도착지'
+                value={toLocation}
+                onChange={setToLocation}
+                placeholder='도착 위치를 입력하세요'
+                disableLabelAnimation={true}
+              />
             </div>
           </div>
         );
 
       case 'hotel':
         return (
-          <div className='space-y-4'>
+          <div className='space-y-6'>
             <div className='grid grid-cols-2 gap-4'>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  체크인
-                </label>
-                <input
-                  type='date'
-                  value={checkIn}
-                  onChange={(e) => setCheckIn(e.target.value)}
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  체크아웃
-                </label>
-                <input
-                  type='date'
-                  value={checkOut}
-                  onChange={(e) => setCheckOut(e.target.value)}
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-              </div>
-            </div>
-            <div>
-              <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                객실 타입
-              </label>
-              <input
-                type='text'
-                value={roomType}
-                onChange={(e) => setRoomType(e.target.value)}
-                placeholder='예: 디럭스 더블룸'
-                className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
+              <SmartInput
+                label='체크인'
+                value={checkIn}
+                onChange={setCheckIn}
+                type='date'
+                disableLabelAnimation={true}
+              />
+              <SmartInput
+                label='체크아웃'
+                value={checkOut}
+                onChange={setCheckOut}
+                type='date'
+                disableLabelAnimation={true}
               />
             </div>
+
+            <SmartInput
+              label='객실 타입'
+              value={roomType}
+              onChange={setRoomType}
+              placeholder='예: 디럭스 더블룸, 스위트룸'
+              disableLabelAnimation={true}
+            />
           </div>
         );
 
       case 'food':
         return (
-          <div className='space-y-4'>
+          <div className='space-y-6'>
             <div className='grid grid-cols-2 gap-4'>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  식사 종류
-                </label>
+              <div className='relative'>
                 <select
                   value={mealType}
                   onChange={(e) => setMealType(e.target.value)}
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
+                  className='w-full rounded-2xl border-2 border-gray-200 bg-gray-50/50 px-4 py-4 pb-2 pt-6 text-gray-900 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0'
                 >
                   <option value=''>선택하세요</option>
-                  <option value='breakfast'>아침식사</option>
-                  <option value='lunch'>점심식사</option>
-                  <option value='dinner'>저녁식사</option>
-                  <option value='snack'>간식</option>
+                  <option value='breakfast'>🌅 아침식사</option>
+                  <option value='lunch'>☀️ 점심식사</option>
+                  <option value='dinner'>🌙 저녁식사</option>
+                  <option value='snack'>🍿 간식</option>
                 </select>
-              </div>
-              <div>
-                <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                  요리 종류
+                <label className='absolute left-4 top-2 text-xs font-medium text-gray-500'>
+                  식사 종류
                 </label>
-                <input
-                  type='text'
-                  value={cuisine}
-                  onChange={(e) => setCuisine(e.target.value)}
-                  placeholder='예: 일식, 한식, 중식'
-                  className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
               </div>
+
+              <SmartInput
+                label='요리 종류'
+                value={cuisine}
+                onChange={setCuisine}
+                placeholder='예: 일식, 한식, 중식'
+                disableLabelAnimation={true}
+              />
             </div>
           </div>
         );
 
       case 'activity':
         return (
-          <div className='space-y-4'>
-            <div>
-              <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                액티비티 종류
-              </label>
+          <div className='space-y-6'>
+            <div className='relative'>
               <select
                 value={activityType}
                 onChange={(e) => setActivityType(e.target.value)}
-                className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
+                className='w-full rounded-2xl border-2 border-gray-200 bg-gray-50/50 px-4 py-4 pb-2 pt-6 text-gray-900 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0'
               >
                 <option value=''>선택하세요</option>
-                <option value='sightseeing'>관광</option>
-                <option value='shopping'>쇼핑</option>
-                <option value='entertainment'>엔터테인먼트</option>
-                <option value='sports'>스포츠</option>
-                <option value='culture'>문화</option>
+                <option value='sightseeing'>🏛️ 관광</option>
+                <option value='shopping'>🛍️ 쇼핑</option>
+                <option value='entertainment'>🎭 엔터테인먼트</option>
+                <option value='sports'>⚽ 스포츠</option>
+                <option value='culture'>🎨 문화</option>
               </select>
-            </div>
-            <div className='flex items-center space-x-3'>
-              <input
-                type='checkbox'
-                id='reservationRequired'
-                checked={reservationRequired}
-                onChange={(e) => setReservationRequired(e.target.checked)}
-                className='h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-blue-500'
-              />
-              <label
-                htmlFor='reservationRequired'
-                className='text-sm font-medium text-gray-700'
-              >
-                예약 필요
+              <label className='absolute left-4 top-2 text-xs font-medium text-gray-500'>
+                액티비티 종류
               </label>
             </div>
+
+            <motion.div
+              whileTap={{ scale: 0.98 }}
+              className='flex cursor-pointer items-center space-x-3 rounded-2xl border-2 border-gray-200 bg-gray-50/50 p-4 transition-all hover:bg-gray-100/50'
+              onClick={() => setReservationRequired(!reservationRequired)}
+            >
+              <div
+                className={`flex h-6 w-6 items-center justify-center rounded-lg border-2 transition-all ${
+                  reservationRequired
+                    ? 'border-blue-500 bg-blue-500'
+                    : 'border-gray-300 bg-white'
+                }`}
+              >
+                {reservationRequired && (
+                  <IoCheckmarkOutline className='h-4 w-4 text-white' />
+                )}
+              </div>
+              <div className='flex-1'>
+                <Typography
+                  variant='body2'
+                  className='font-medium text-gray-700'
+                >
+                  예약 필요
+                </Typography>
+                <Typography variant='caption' className='text-gray-500'>
+                  미리 예약이 필요한 액티비티인가요?
+                </Typography>
+              </div>
+            </motion.div>
           </div>
         );
 
@@ -453,181 +465,120 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
     }
   };
 
-  if (!isOpen) return null;
+  const handleModalClose = () => {
+    // 백드랍 클릭으로는 닫히지 않도록 빈 함수
+  };
 
-  const modalContent = (
-    <div className='fixed inset-0 z-[9999] flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm'>
-      <div className='mx-4 max-h-[90vh] w-full max-w-lg overflow-auto rounded-2xl bg-white shadow-2xl'>
-        <div className='flex items-center justify-between border-b border-gray-100 p-6'>
-          <div>
-            <Typography variant='h4' className='mb-1 text-gray-900'>
-              새 일정 추가
-            </Typography>
-            <Typography variant='caption' className='text-gray-500'>
-              Day {dayNumber} ·{' '}
-              {new Date().toLocaleDateString('ko-KR', {
-                month: 'long',
-                day: 'numeric',
-                weekday: 'short',
-              })}
-            </Typography>
-          </div>
-          <button
-            onClick={handleClose}
-            className='rounded-xl p-2 transition-colors hover:bg-gray-100'
-          >
-            <IoCloseOutline className='h-5 w-5 text-gray-500' />
-          </button>
-        </div>
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleModalClose}
+      width='full'
+      modalType='component'
+      showCloseButton={false}
+    >
+      <div className='mx-auto max-w-4xl px-4 sm:px-6 lg:px-8'>
+        <div className='max-h-[80vh] overflow-y-auto'>
+          {/* 헤더 */}
+          {renderBlockTypeSelection()}
 
-        <form onSubmit={handleSubmit} className='space-y-6 p-6'>
-          <div>
-            <Typography
-              variant='body1'
-              className='mb-4 font-semibold text-gray-800'
-            >
-              일정 유형
-            </Typography>
-            <div className='grid grid-cols-3 gap-3'>
-              {blockTypes.map((blockType) => (
-                <button
-                  key={blockType.type}
-                  type='button'
-                  onClick={() => setSelectedType(blockType.type)}
-                  className={`rounded-xl border-2 p-4 transition-all ${
-                    selectedType === blockType.type
-                      ? 'scale-105 border-blue-500 bg-blue-50'
-                      : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
-                  }`}
-                >
-                  <div className='flex flex-col items-center space-y-2'>
-                    <div className={blockType.color}>{blockType.icon}</div>
-                    <Typography
-                      variant='caption'
-                      className='font-medium text-gray-700'
-                    >
-                      {blockType.label}
-                    </Typography>
-                  </div>
-                </button>
-              ))}
-            </div>
-          </div>
+          {/* 폼 */}
+          <form onSubmit={handleSubmit} className='space-y-6 p-6'>
+            {/* 기본 정보 섹션 */}
+            <div className='space-y-6'>
+              <SmartInput
+                label='제목'
+                value={title}
+                onChange={setTitle}
+                placeholder='일정 제목을 입력하세요'
+                required
+                disableLabelAnimation={true}
+              />
 
-          <div>
-            <label className='mb-3 block text-sm font-semibold text-gray-800'>
-              제목 <span className='text-red-500'>*</span>
-            </label>
-            <input
-              type='text'
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder='일정 제목을 입력하세요'
-              className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-              required
-            />
-          </div>
+              <SmartInput
+                label='설명'
+                value={description}
+                onChange={setDescription}
+                type='textarea'
+                placeholder='자세한 설명을 입력하세요'
+                disableLabelAnimation={true}
+              />
 
-          <div>
-            <label className='mb-3 block text-sm font-semibold text-gray-800'>
-              설명
-            </label>
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder='자세한 설명을 입력하세요'
-              rows={3}
-              className='w-full resize-none rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-            />
-          </div>
+              <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+                <SmartInput
+                  label='위치'
+                  value={address}
+                  onChange={setAddress}
+                  placeholder='주소 또는 장소명'
+                  disableLabelAnimation={true}
+                />
 
-          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
-            <div>
-              <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                위치
-              </label>
-              <input
-                type='text'
-                value={address}
-                onChange={(e) => setAddress(e.target.value)}
-                placeholder='주소 또는 장소명'
-                className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
+                <SmartBudgetInput
+                  value={amount}
+                  onChange={setAmount}
+                  currency={currency}
+                  onCurrencyChange={setCurrency}
+                  totalBudget={totalBudget}
+                />
+              </div>
+
+              <SmartTimeInput
+                startTime={startTime}
+                endTime={endTime}
+                onStartTimeChange={setStartTime}
+                onEndTimeChange={setEndTime}
+                suggestedDuration={suggestedDuration}
               />
             </div>
 
-            <div>
-              <label className='mb-3 block text-sm font-semibold text-gray-800'>
-                예상 비용
-              </label>
-              <div className='relative'>
-                <input
-                  type='text'
-                  value={amount}
-                  onChange={(e) =>
-                    setAmount(formatCurrencyInput(e.target.value))
-                  }
-                  placeholder='0'
-                  className='w-full rounded-xl border border-gray-300 py-3 pl-10 pr-4 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                />
-                <span className='absolute left-4 top-3 font-medium text-gray-500'>
-                  {CURRENCIES[currency].symbol}
-                </span>
+            {/* 블록 타입별 전용 필드 */}
+            {renderTypeSpecificFields()}
+
+            {/* 제출 버튼 */}
+            <div className='sticky bottom-0 -mx-6 border-t border-gray-100 bg-white px-6 pb-6 pt-6'>
+              <div className='flex space-x-3'>
+                <Button
+                  type='button'
+                  variant='outlined'
+                  size='large'
+                  onClick={handleClose}
+                  className='flex-1 rounded-2xl border-gray-300 text-gray-600 hover:bg-gray-50'
+                  disabled={isLoading}
+                >
+                  취소
+                </Button>
+                <motion.div
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  className='flex-1'
+                >
+                  <Button
+                    type='submit'
+                    variant='filled'
+                    size='large'
+                    className={`w-full rounded-2xl font-semibold transition-all ${
+                      !title.trim()
+                        ? 'cursor-not-allowed bg-gray-200 text-gray-400'
+                        : 'bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-lg hover:shadow-xl'
+                    }`}
+                    disabled={isLoading || !title.trim()}
+                  >
+                    {isLoading ? (
+                      <div className='flex items-center space-x-2'>
+                        <div className='h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent' />
+                        <span>추가 중...</span>
+                      </div>
+                    ) : (
+                      // `${currentBlockConfig?.label || '일정'} 추가하기`
+                      '추가하기'
+                    )}
+                  </Button>
+                </motion.div>
               </div>
             </div>
-          </div>
-
-          <div>
-            <label className='mb-3 block text-sm font-semibold text-gray-800'>
-              시간
-            </label>
-            <div className='grid grid-cols-2 gap-4'>
-              <input
-                type='time'
-                value={startTime}
-                onChange={(e) => setStartTime(e.target.value)}
-                className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                placeholder='시작 시간'
-              />
-              <input
-                type='time'
-                value={endTime}
-                onChange={(e) => setEndTime(e.target.value)}
-                className='w-full rounded-xl border border-gray-300 px-4 py-3 transition-all focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-20'
-                placeholder='종료 시간'
-              />
-            </div>
-          </div>
-
-          {renderTypeSpecificFields()}
-
-          <div className='flex space-x-3 border-t border-gray-100 pt-6'>
-            <Button
-              type='button'
-              variant='outlined'
-              size='medium'
-              onClick={handleClose}
-              className='flex-1 rounded-xl'
-              disabled={isLoading}
-            >
-              취소
-            </Button>
-            <Button
-              type='submit'
-              variant='filled'
-              size='medium'
-              className='flex-1 rounded-xl'
-              disabled={isLoading || !title.trim()}
-            >
-              {isLoading ? '추가 중...' : '일정 추가'}
-            </Button>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
-    </div>
+    </Modal>
   );
-
-  // SSR 환경에서 document가 없는 경우를 대비한 안전한 포털 렌더링
-  return typeof window !== 'undefined'
-    ? createPortal(modalContent, document.body)
-    : null;
 };

--- a/apps/web/src/components/travel/detail/BlockCreateModal.tsx
+++ b/apps/web/src/components/travel/detail/BlockCreateModal.tsx
@@ -11,10 +11,8 @@ import { Button, Typography } from '@ui/components';
 import { Modal } from '@/components/basic/Modal';
 import {
   blockTypeConfigs,
-  getArrivalAirportSuggestions,
   getDefaultCurrencyForBlock,
   getDefaultDuration,
-  getDepartureAirportSuggestions,
 } from '@/lib/block-helpers';
 import { CurrencyCode, parseCurrencyInput } from '@/lib/currency';
 import { BlockType, CreateBlockRequest } from '@/types/travel/blocks';
@@ -289,16 +287,14 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
                 label='출발공항'
                 value={departureAirport}
                 onChange={setDepartureAirport}
-                placeholder='공항을 선택하세요'
-                suggestions={getDepartureAirportSuggestions(userNationality)}
+                placeholder='예: 인천국제공항 (ICN)'
                 disableLabelAnimation={true}
               />
               <SmartInput
                 label='도착공항'
                 value={arrivalAirport}
                 onChange={setArrivalAirport}
-                placeholder='공항을 선택하세요'
-                suggestions={getArrivalAirportSuggestions(planLocation)}
+                placeholder='예: 나리타공항 (NRT)'
                 disableLabelAnimation={true}
               />
             </div>
@@ -332,14 +328,14 @@ export const BlockCreateModal: React.FC<BlockCreateModalProps> = ({
                 label='출발지'
                 value={fromLocation}
                 onChange={setFromLocation}
-                placeholder='출발 위치를 입력하세요'
+                placeholder='예: 강남역, 인천공항'
                 disableLabelAnimation={true}
               />
               <SmartInput
                 label='도착지'
                 value={toLocation}
                 onChange={setToLocation}
-                placeholder='도착 위치를 입력하세요'
+                placeholder='예: 홍대입구역, 호텔'
                 disableLabelAnimation={true}
               />
             </div>

--- a/apps/web/src/components/travel/detail/BlockDetailModal.tsx
+++ b/apps/web/src/components/travel/detail/BlockDetailModal.tsx
@@ -363,30 +363,6 @@ export const BlockDetailModal: React.FC<BlockDetailModalProps> = ({
             )}
           </div>
         </div>
-
-        {/* 액션 버튼 */}
-        {canEdit && (
-          <div className='flex space-x-3 border-t border-gray-100 p-6'>
-            <Button
-              type='button'
-              variant='filled'
-              size='medium'
-              onClick={handleEdit}
-              className='flex-1 rounded-xl'
-            >
-              수정
-            </Button>
-            <Button
-              type='button'
-              variant='outlined'
-              size='medium'
-              onClick={handleDelete}
-              className='flex-1 rounded-xl border-red-600 text-red-600 hover:bg-red-50'
-            >
-              삭제
-            </Button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/travel/detail/BlockDetailModal.tsx
+++ b/apps/web/src/components/travel/detail/BlockDetailModal.tsx
@@ -30,8 +30,6 @@ interface BlockDetailModalProps {
   canEdit?: boolean;
 }
 
-// 프리젠테이션 유틸은 import로 대체
-
 export const BlockDetailModal: React.FC<BlockDetailModalProps> = ({
   isOpen,
   onClose,
@@ -163,7 +161,9 @@ export const BlockDetailModal: React.FC<BlockDetailModalProps> = ({
                     위치
                   </Typography>
                   <Typography variant='body2' className='text-gray-600'>
-                    {block.location.address}
+                    {typeof block.location === 'string'
+                      ? block.location
+                      : block.location.address || '위치 정보 없음'}
                   </Typography>
                 </div>
               </div>
@@ -191,13 +191,6 @@ export const BlockDetailModal: React.FC<BlockDetailModalProps> = ({
           {/* 블록 타입별 상세 정보 */}
           {block.meta && (
             <div className='space-y-4'>
-              <Typography
-                variant='body1'
-                className='font-semibold text-gray-800'
-              >
-                상세 정보
-              </Typography>
-
               <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
                 {/* 교통수단 */}
                 {block.meta.transportType && (
@@ -224,7 +217,10 @@ export const BlockDetailModal: React.FC<BlockDetailModalProps> = ({
                       출발지
                     </Typography>
                     <Typography variant='body2' className='text-blue-600'>
-                      {block.meta.fromLocation.address}
+                      {typeof block.meta.fromLocation === 'string'
+                        ? block.meta.fromLocation
+                        : (block.meta.fromLocation as { address?: string })
+                            ?.address || '출발지 정보 없음'}
                     </Typography>
                   </div>
                 )}
@@ -239,7 +235,10 @@ export const BlockDetailModal: React.FC<BlockDetailModalProps> = ({
                       도착지
                     </Typography>
                     <Typography variant='body2' className='text-blue-600'>
-                      {block.meta.toLocation.address}
+                      {typeof block.meta.toLocation === 'string'
+                        ? block.meta.toLocation
+                        : (block.meta.toLocation as { address?: string })
+                            ?.address || '도착지 정보 없음'}
                     </Typography>
                   </div>
                 )}
@@ -368,15 +367,6 @@ export const BlockDetailModal: React.FC<BlockDetailModalProps> = ({
         {/* 액션 버튼 */}
         {canEdit && (
           <div className='flex space-x-3 border-t border-gray-100 p-6'>
-            <Button
-              type='button'
-              variant='outlined'
-              size='medium'
-              onClick={onClose}
-              className='flex-1 rounded-xl'
-            >
-              닫기
-            </Button>
             <Button
               type='button'
               variant='filled'

--- a/apps/web/src/components/travel/detail/SmartInputs.tsx
+++ b/apps/web/src/components/travel/detail/SmartInputs.tsx
@@ -1,0 +1,382 @@
+import React, { useEffect, useState } from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import {
+  IoCheckmarkOutline,
+  IoChevronDownOutline,
+  IoInformationCircleOutline,
+  IoTimeOutline,
+} from 'react-icons/io5';
+
+import { Button, Typography } from '@ui/components';
+
+import { addMinutes, formatDuration } from '@/lib/block-helpers';
+import {
+  CURRENCIES,
+  CurrencyCode,
+  formatCurrencyInput,
+  parseCurrencyInput,
+} from '@/lib/currency';
+
+interface SmartInputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: 'text' | 'time' | 'date' | 'textarea';
+  placeholder?: string;
+  required?: boolean;
+  suggestions?: string[];
+  className?: string;
+  disableLabelAnimation?: boolean;
+}
+
+export const SmartInput: React.FC<SmartInputProps> = ({
+  label,
+  value,
+  onChange,
+  type = 'text',
+  placeholder,
+  required = false,
+  suggestions = [],
+  className = '',
+  disableLabelAnimation = false,
+}) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const hasValue = value.length > 0;
+  const shouldFloat =
+    hasValue || isFocused || type === 'time' || type === 'date';
+
+  const handleSuggestionClick = (suggestion: string) => {
+    onChange(suggestion);
+    setShowSuggestions(false);
+  };
+
+  const inputElement =
+    type === 'textarea' ? (
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => {
+          setIsFocused(true);
+          if (suggestions.length > 0) setShowSuggestions(true);
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+          setTimeout(() => setShowSuggestions(false), 150);
+        }}
+        placeholder={shouldFloat ? placeholder : ''}
+        rows={3}
+        className={`peer w-full resize-none rounded-2xl border-2 bg-gray-50/50 px-4 pb-3 pt-6 text-gray-900 placeholder-gray-400 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0 ${
+          hasValue ? 'border-gray-300' : 'border-gray-200'
+        } ${className}`}
+      />
+    ) : (
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => {
+          setIsFocused(true);
+          if (suggestions.length > 0) setShowSuggestions(true);
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+          setTimeout(() => setShowSuggestions(false), 150);
+        }}
+        placeholder={shouldFloat ? placeholder : ''}
+        className={`peer w-full rounded-2xl border-2 bg-gray-50/50 px-4 py-4 text-gray-900 placeholder-gray-400 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0 ${
+          hasValue ? 'border-gray-300' : 'border-gray-200'
+        } ${shouldFloat ? 'pb-2 pt-6' : 'pb-4 pt-4'} ${className}`}
+      />
+    );
+
+  return (
+    <div className='relative'>
+      {inputElement}
+
+      {/* 플로팅 라벨 */}
+      {disableLabelAnimation ? (
+        <label className='pointer-events-none absolute left-4 top-2 text-xs font-medium text-gray-500'>
+          {label}
+          {required && <span className='ml-1 text-red-500'>*</span>}
+        </label>
+      ) : (
+        <motion.label
+          animate={{
+            top: shouldFloat ? '0.5rem' : '1rem',
+            fontSize: shouldFloat ? '0.75rem' : '1rem',
+            color: isFocused ? '#3b82f6' : hasValue ? '#6b7280' : '#9ca3af',
+          }}
+          transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
+          className='pointer-events-none absolute left-4 origin-left font-medium'
+        >
+          {label}
+          {required && <span className='ml-1 text-red-500'>*</span>}
+        </motion.label>
+      )}
+
+      {/* 자동완성 제안 */}
+      <AnimatePresence>
+        {showSuggestions && suggestions.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.15 }}
+            className='absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg'
+          >
+            {suggestions.map((suggestion, index) => (
+              <button
+                key={index}
+                type='button'
+                onClick={() => handleSuggestionClick(suggestion)}
+                className='w-full px-4 py-3 text-left text-sm first:rounded-t-xl last:rounded-b-xl hover:bg-gray-50 focus:bg-blue-50 focus:outline-none'
+              >
+                {suggestion}
+              </button>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+interface SmartBudgetInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  currency: CurrencyCode;
+  onCurrencyChange: (currency: CurrencyCode) => void;
+  totalBudget?: number;
+  className?: string;
+}
+
+export const SmartBudgetInput: React.FC<SmartBudgetInputProps> = ({
+  value,
+  onChange,
+  currency,
+  onCurrencyChange,
+  totalBudget = 0,
+  className = '',
+}) => {
+  const [showCurrencySelect, setShowCurrencySelect] = useState(false);
+  const percentage =
+    totalBudget > 0 ? (parseCurrencyInput(value) / totalBudget) * 100 : 0;
+
+  const popularCurrencies: CurrencyCode[] = [
+    'KRW',
+    'USD',
+    'JPY',
+    'EUR',
+    'CNY',
+    'THB',
+  ];
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      <div className='relative'>
+        <input
+          type='text'
+          value={value}
+          onChange={(e) => onChange(formatCurrencyInput(e.target.value))}
+          className='w-full rounded-2xl border-2 border-gray-200 bg-gray-50/50 py-4 pl-16 pr-20 text-lg font-semibold placeholder-gray-400 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0'
+          placeholder='0'
+        />
+
+        {/* 통화 심볼 */}
+        <div className='absolute left-4 top-1/2 -translate-y-1/2'>
+          <span className='text-lg font-bold text-gray-600'>
+            {CURRENCIES[currency].symbol}
+          </span>
+        </div>
+
+        {/* 통화 선택 버튼 */}
+        <button
+          type='button'
+          onClick={() => setShowCurrencySelect(!showCurrencySelect)}
+          className='absolute right-2 top-1/2 flex -translate-y-1/2 items-center space-x-1 rounded-xl bg-gray-100 px-3 py-2 text-sm font-medium transition-colors hover:bg-gray-200'
+        >
+          <span>{currency}</span>
+          <IoChevronDownOutline
+            className={`h-4 w-4 transition-transform ${showCurrencySelect ? 'rotate-180' : ''}`}
+          />
+        </button>
+
+        {/* 통화 선택 드롭다운 */}
+        <AnimatePresence>
+          {showCurrencySelect && (
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              className='absolute right-0 top-full z-10 mt-1 w-48 rounded-xl border border-gray-200 bg-white shadow-lg'
+            >
+              {popularCurrencies.map((curr) => (
+                <button
+                  key={curr}
+                  type='button'
+                  onClick={() => {
+                    onCurrencyChange(curr);
+                    setShowCurrencySelect(false);
+                  }}
+                  className='flex w-full items-center justify-between px-4 py-3 text-left text-sm first:rounded-t-xl last:rounded-b-xl hover:bg-gray-50 focus:bg-blue-50 focus:outline-none'
+                >
+                  <div className='flex items-center space-x-3'>
+                    <span className='font-medium'>
+                      {CURRENCIES[curr].symbol}
+                    </span>
+                    <span>{curr}</span>
+                  </div>
+                  {currency === curr && (
+                    <IoCheckmarkOutline className='h-4 w-4 text-blue-500' />
+                  )}
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* 예산 비율 표시 */}
+      {totalBudget > 0 && parseCurrencyInput(value) > 0 && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          transition={{ duration: 0.2 }}
+          className='flex items-center space-x-3'
+        >
+          <div className='h-2 flex-1 overflow-hidden rounded-full bg-gray-100'>
+            <motion.div
+              className={`h-full rounded-full ${
+                percentage > 100
+                  ? 'bg-red-400'
+                  : percentage > 70
+                    ? 'bg-yellow-400'
+                    : 'bg-green-400'
+              }`}
+              initial={{ width: 0 }}
+              animate={{ width: `${Math.min(percentage, 100)}%` }}
+              transition={{ duration: 0.3 }}
+            />
+          </div>
+          <Typography
+            variant='caption'
+            className={`min-w-[3rem] font-medium ${
+              percentage > 100 ? 'text-red-500' : 'text-gray-600'
+            }`}
+          >
+            {percentage.toFixed(1)}%
+          </Typography>
+        </motion.div>
+      )}
+
+      {/* 예산 초과 경고 */}
+      {percentage > 100 && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className='flex items-center space-x-2 rounded-xl bg-red-50 p-3'
+        >
+          <div className='flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-red-100'>
+            <IoInformationCircleOutline className='h-3 w-3 text-red-600' />
+          </div>
+          <Typography variant='caption' className='text-red-700'>
+            예산을 초과했습니다. 다른 항목을 조정해보세요.
+          </Typography>
+        </motion.div>
+      )}
+    </div>
+  );
+};
+
+interface SmartTimeInputProps {
+  startTime: string;
+  endTime: string;
+  onStartTimeChange: (time: string) => void;
+  onEndTimeChange: (time: string) => void;
+  suggestedDuration?: number;
+  className?: string;
+}
+
+export const SmartTimeInput: React.FC<SmartTimeInputProps> = ({
+  startTime,
+  endTime,
+  onStartTimeChange,
+  onEndTimeChange,
+  suggestedDuration = 0,
+  className = '',
+}) => {
+  const [showSuggestion, setShowSuggestion] = useState(false);
+
+  useEffect(() => {
+    // 시작 시간이 있고 종료 시간이 없으며 추천 시간이 있을 때 제안 표시
+    setShowSuggestion(Boolean(startTime && !endTime && suggestedDuration > 0));
+  }, [startTime, endTime, suggestedDuration]);
+
+  const handleApplySuggestion = () => {
+    if (startTime && suggestedDuration > 0) {
+      onEndTimeChange(addMinutes(startTime, suggestedDuration));
+      setShowSuggestion(false);
+    }
+  };
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      <div className='grid grid-cols-2 gap-4'>
+        <SmartInput
+          label='시작 시간'
+          value={startTime}
+          onChange={onStartTimeChange}
+          type='time'
+          disableLabelAnimation={true}
+        />
+        <SmartInput
+          label='종료 시간'
+          value={endTime}
+          onChange={onEndTimeChange}
+          type='time'
+          disableLabelAnimation={true}
+        />
+      </div>
+
+      {/* 스마트 시간 제안 */}
+      <AnimatePresence>
+        {showSuggestion && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.2 }}
+            className='flex items-center space-x-3 rounded-2xl bg-blue-50 p-4'
+          >
+            <div className='flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-100'>
+              <IoTimeOutline className='h-5 w-5 text-blue-600' />
+            </div>
+            <div className='flex-1'>
+              <Typography
+                variant='body2'
+                className='font-semibold text-blue-900'
+              >
+                {formatDuration(suggestedDuration)} 소요 예상
+              </Typography>
+              <Typography variant='caption' className='text-blue-600'>
+                종료 시간을 자동으로 설정할까요?
+              </Typography>
+            </div>
+            <Button
+              type='button'
+              size='small'
+              variant='filled'
+              onClick={handleApplySuggestion}
+              className='rounded-xl bg-blue-500 px-4 py-2 text-white hover:bg-blue-600'
+            >
+              적용
+            </Button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/apps/web/src/components/travel/detail/TravelBlockItem.tsx
+++ b/apps/web/src/components/travel/detail/TravelBlockItem.tsx
@@ -198,7 +198,11 @@ export const TravelBlockItem: React.FC<TravelBlockItemProps> = ({
           {block.location && (
             <div className='flex items-center space-x-2 text-sm text-gray-600'>
               <IoLocationOutline className='h-4 w-4 text-gray-400' />
-              <span className='truncate'>{block.location.address}</span>
+              <span className='truncate'>
+                {typeof block.location === 'string'
+                  ? block.location
+                  : block.location.address || '위치 정보 없음'}
+              </span>
             </div>
           )}
 

--- a/apps/web/src/components/travel/detail/TravelBlockItem.tsx
+++ b/apps/web/src/components/travel/detail/TravelBlockItem.tsx
@@ -71,12 +71,12 @@ export const TravelBlockItem: React.FC<TravelBlockItemProps> = ({
     <div
       ref={setNodeRef}
       style={style}
-      className={`group relative rounded-xl border bg-white transition-all duration-200 ${
-        isDragging ? 'scale-105 opacity-50 shadow-2xl' : ''
+      className={`group relative overflow-hidden rounded-2xl border bg-white transition-all duration-300 ${
+        isDragging ? 'scale-105 opacity-50 shadow-2xl ring-4 ring-blue-100' : ''
       } ${
         isHovered
-          ? 'border-gray-300 shadow-lg'
-          : 'border-gray-200 shadow-sm hover:border-gray-300 hover:shadow-md'
+          ? '-translate-y-1 border-gray-300 shadow-xl shadow-gray-100/50'
+          : 'border-gray-200/60 shadow-md shadow-gray-100/30 hover:border-gray-300 hover:shadow-lg hover:shadow-gray-100/40'
       } ${onClick ? 'cursor-pointer' : ''}`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
@@ -87,18 +87,18 @@ export const TravelBlockItem: React.FC<TravelBlockItemProps> = ({
         <div
           {...attributes}
           {...listeners}
-          className={`absolute left-2 top-1/2 -translate-y-1/2 rounded-md p-1 transition-colors ${
+          className={`absolute left-3 top-1/2 -translate-y-1/2 rounded-lg p-1.5 transition-all duration-200 ${
             isHovered
-              ? 'bg-gray-100 text-gray-600'
-              : 'text-gray-400 opacity-0 group-hover:opacity-100'
-          } cursor-grab active:cursor-grabbing`}
+              ? 'scale-110 bg-gray-100/80 text-gray-600'
+              : 'text-gray-300 opacity-0 group-hover:text-gray-400 group-hover:opacity-100'
+          } cursor-grab active:scale-95 active:cursor-grabbing`}
           onClick={(e) => e.stopPropagation()} // 카드 클릭 이벤트 방지
         >
-          <IoSwapVerticalOutline className='h-4 w-4' />
+          <IoSwapVerticalOutline className='h-3.5 w-3.5' />
         </div>
       )}
 
-      <div className={`p-4 ${canEdit ? 'pl-10' : ''}`}>
+      <div className={`p-5 ${canEdit ? 'pl-12' : ''}`}>
         {/* 헤더 영역 */}
         <div className='mb-3 flex items-start justify-between'>
           <div className='flex items-center space-x-3'>
@@ -123,11 +123,11 @@ export const TravelBlockItem: React.FC<TravelBlockItemProps> = ({
           {/* 메뉴 버튼 */}
           {canEdit && (
             <button
-              className={`rounded-md p-1 transition-colors ${
+              className={`rounded-lg p-1.5 transition-all duration-200 ${
                 isHovered
-                  ? 'bg-gray-100 text-gray-600'
-                  : 'text-gray-400 opacity-0 group-hover:opacity-100'
-              }`}
+                  ? 'scale-110 bg-gray-100/80 text-gray-600'
+                  : 'text-gray-300 opacity-0 group-hover:text-gray-400 group-hover:opacity-100'
+              } hover:bg-gray-200/60 active:scale-95`}
               onClick={(e) => e.stopPropagation()}
             >
               <IoEllipsisVerticalOutline className='h-4 w-4' />
@@ -212,7 +212,6 @@ export const TravelBlockItem: React.FC<TravelBlockItemProps> = ({
             </div>
           )}
         </div>
-        <div className='mt-3 border-t border-gray-100 pt-3' />
       </div>
     </div>
   );

--- a/apps/web/src/components/travel/detail/TravelBlockItem.tsx
+++ b/apps/web/src/components/travel/detail/TravelBlockItem.tsx
@@ -39,6 +39,7 @@ export const TravelBlockItem: React.FC<TravelBlockItemProps> = ({
   block,
   canEdit,
   onClick,
+  onEdit,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
@@ -128,7 +129,10 @@ export const TravelBlockItem: React.FC<TravelBlockItemProps> = ({
                   ? 'scale-110 bg-gray-100/80 text-gray-600'
                   : 'text-gray-300 opacity-0 group-hover:text-gray-400 group-hover:opacity-100'
               } hover:bg-gray-200/60 active:scale-95`}
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!isDragging && onEdit) onEdit(block);
+              }}
             >
               <IoEllipsisVerticalOutline className='h-4 w-4' />
             </button>

--- a/apps/web/src/components/travel/detail/TravelTimelineCanvas.tsx
+++ b/apps/web/src/components/travel/detail/TravelTimelineCanvas.tsx
@@ -35,6 +35,7 @@ interface TravelTimelineCanvasProps {
     newOrderIndex: number
   ) => void;
   onBlockClick?: (block: TravelBlock) => void;
+  onBlockEdit?: (block: TravelBlock) => void;
 }
 
 export const TravelTimelineCanvas: React.FC<TravelTimelineCanvasProps> = ({
@@ -45,6 +46,7 @@ export const TravelTimelineCanvas: React.FC<TravelTimelineCanvasProps> = ({
   onBlockCreate: _onBlockCreate,
   onBlockMove,
   onBlockClick,
+  onBlockEdit,
 }) => {
   // 선택된 날짜의 블록 데이터 추출
   const selectedDayData = timeline.days.find(
@@ -100,6 +102,7 @@ export const TravelTimelineCanvas: React.FC<TravelTimelineCanvasProps> = ({
                   block={block}
                   canEdit={canEdit}
                   onClick={onBlockClick}
+                  onEdit={onBlockEdit}
                 />
               ))}
             </div>

--- a/apps/web/src/components/travel/detail/TravelTimelineCanvas.tsx
+++ b/apps/web/src/components/travel/detail/TravelTimelineCanvas.tsx
@@ -37,19 +37,6 @@ interface TravelTimelineCanvasProps {
   onBlockClick?: (block: TravelBlock) => void;
 }
 
-// 블록 타입별 아이콘 매핑 함수
-const getBlockIcon = (blockType: BlockType) => {
-  const iconMap = {
-    flight: <IoAirplaneOutline className='h-4 w-4' />,
-    move: <IoCarOutline className='h-4 w-4' />,
-    food: <IoRestaurantOutline className='h-4 w-4' />,
-    hotel: <IoBedOutline className='h-4 w-4' />,
-    activity: <IoGameControllerOutline className='h-4 w-4' />,
-    memo: <IoDocumentTextOutline className='h-4 w-4' />,
-  };
-  return iconMap[blockType] || <IoDocumentTextOutline className='h-4 w-4' />;
-};
-
 export const TravelTimelineCanvas: React.FC<TravelTimelineCanvasProps> = ({
   timeline,
   canEdit,

--- a/apps/web/src/components/travel/detail/flight/BoardingPassCard.tsx
+++ b/apps/web/src/components/travel/detail/flight/BoardingPassCard.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import { IoAirplaneOutline } from 'react-icons/io5';
+
 import { Typography } from '@ui/components';
 
-import { getBlockColor, getBlockLabel } from '../utils/BlockPresentation';
+import { getBlockLabel } from '../utils/BlockPresentation';
 
 interface FlightCardData {
   title: string;
@@ -23,10 +25,21 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
   data,
   compact = false,
 }) => {
-  const color = getBlockColor('flight');
   return (
-    <div className={`overflow-hidden rounded-xl border ${color}`}>
-      <div className={`${compact ? 'p-3' : 'p-4'} bg-white`}>
+    <div className='relative overflow-hidden rounded-2xl border border-sky-200/60 bg-gradient-to-br from-sky-50/30 to-white shadow-lg shadow-sky-100/20'>
+      {/* 배경 패턴 */}
+      <div className='absolute inset-0 opacity-5'>
+        <div className='absolute right-4 top-4 text-6xl text-sky-500'>
+          <IoAirplaneOutline className='rotate-45' />
+        </div>
+      </div>
+
+      {/* 점선 구분 */}
+      <div className='absolute left-0 right-0 top-2/3 border-t-2 border-dashed border-sky-200/40' />
+
+      <div
+        className={`relative ${compact ? 'p-4' : 'p-5'} bg-white/80 backdrop-blur-sm`}
+      >
         <div className='flex items-start justify-between'>
           <div className='flex items-center space-x-2'>
             <span className='rounded-md bg-sky-100 px-2 py-1 text-xs font-semibold text-sky-700'>
@@ -57,32 +70,45 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
         </div>
 
         <div
-          className={`mt-3 grid items-center ${compact ? 'gap-3' : 'gap-4'} grid-cols-5`}
+          className={`mt-4 grid items-center ${compact ? 'gap-3' : 'gap-4'} grid-cols-5`}
         >
           <div className='col-span-2'>
-            <Typography variant='caption' className='text-gray-500'>
-              출발
+            <Typography variant='caption' className='font-medium text-sky-600'>
+              FROM
             </Typography>
-            <Typography
-              variant={compact ? 'body2' : 'body1'}
-              className='truncate font-semibold text-gray-900'
-            >
-              {data.departureAirport ?? '-'}
-            </Typography>
+            <div className='mt-1'>
+              <Typography
+                variant={compact ? 'body1' : 'h6'}
+                className='font-bold tracking-wide text-gray-900'
+              >
+                {data.departureAirport || '---'}
+              </Typography>
+              <Typography variant='caption' className='text-gray-500'>
+                {data.departureAirport || '출발공항'}
+              </Typography>
+            </div>
           </div>
-          <div className='flex items-center justify-center'>
-            <div className='h-px w-full max-w-[60px] bg-sky-300' />
+
+          <div className='flex flex-col items-center justify-center'>
+            <IoAirplaneOutline className='mb-1 h-5 w-5 text-sky-500' />
+            <div className='h-px w-8 bg-gradient-to-r from-sky-300 to-sky-500' />
           </div>
+
           <div className='col-span-2 text-right'>
-            <Typography variant='caption' className='text-gray-500'>
-              도착
+            <Typography variant='caption' className='font-medium text-sky-600'>
+              TO
             </Typography>
-            <Typography
-              variant={compact ? 'body2' : 'body1'}
-              className='truncate font-semibold text-gray-900'
-            >
-              {data.arrivalAirport ?? '-'}
-            </Typography>
+            <div className='mt-1'>
+              <Typography
+                variant={compact ? 'body1' : 'h6'}
+                className='font-bold tracking-wide text-gray-900'
+              >
+                {data.arrivalAirport || '---'}
+              </Typography>
+              <Typography variant='caption' className='text-gray-500'>
+                {data.arrivalAirport || '도착공항'}
+              </Typography>
+            </div>
           </div>
         </div>
 
@@ -109,8 +135,21 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
           </div>
         )}
       </div>
-      <div className='bg-sky-50 px-4 py-2 text-center text-xs text-sky-700'>
-        Boarding Pass
+      <div className='relative bg-gradient-to-r from-sky-100 to-sky-50 px-4 py-3'>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center space-x-2'>
+            <IoAirplaneOutline className='h-3 w-3 text-sky-600' />
+            <Typography
+              variant='caption'
+              className='font-semibold tracking-wider text-sky-700'
+            >
+              BOARDING PASS
+            </Typography>
+          </div>
+          <Typography variant='caption' className='text-sky-600'>
+            ✈️ 여행 계획
+          </Typography>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/travel/detail/flight/BoardingPassCard.tsx
+++ b/apps/web/src/components/travel/detail/flight/BoardingPassCard.tsx
@@ -26,7 +26,10 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
   compact = false,
 }) => {
   return (
-    <div className='relative overflow-hidden rounded-2xl border border-sky-200/60 bg-gradient-to-br from-sky-50/30 to-white shadow-lg shadow-sky-100/20'>
+    <div className='relative overflow-hidden rounded-2xl border border-sky-200/60 shadow-md shadow-sky-100/20'>
+      {/* 내부 그라디언트 레이어 */}
+      <div className='absolute inset-0 bg-gradient-to-br from-sky-50 to-white' />
+
       {/* 배경 패턴 */}
       <div className='absolute inset-0 opacity-5'>
         <div className='absolute right-4 top-4 text-6xl text-sky-500'>
@@ -34,12 +37,7 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
         </div>
       </div>
 
-      {/* 점선 구분 */}
-      <div className='absolute left-0 right-0 top-2/3 border-t-2 border-dashed border-sky-200/40' />
-
-      <div
-        className={`relative ${compact ? 'p-4' : 'p-5'} bg-white/80 backdrop-blur-sm`}
-      >
+      <div className={`relative ${compact ? 'p-4' : 'p-5'}`}>
         <div className='flex items-start justify-between'>
           <div className='flex items-center space-x-2'>
             <span className='rounded-md bg-sky-100 px-2 py-1 text-xs font-semibold text-sky-700'>
@@ -81,9 +79,6 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
                 variant={compact ? 'body1' : 'h6'}
                 className='font-bold tracking-wide text-gray-900'
               >
-                {data.departureAirport || '---'}
-              </Typography>
-              <Typography variant='caption' className='text-gray-500'>
                 {data.departureAirport || '출발공항'}
               </Typography>
             </div>
@@ -91,7 +86,6 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
 
           <div className='flex flex-col items-center justify-center'>
             <IoAirplaneOutline className='mb-1 h-5 w-5 text-sky-500' />
-            <div className='h-px w-8 bg-gradient-to-r from-sky-300 to-sky-500' />
           </div>
 
           <div className='col-span-2 text-right'>
@@ -103,9 +97,6 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
                 variant={compact ? 'body1' : 'h6'}
                 className='font-bold tracking-wide text-gray-900'
               >
-                {data.arrivalAirport || '---'}
-              </Typography>
-              <Typography variant='caption' className='text-gray-500'>
                 {data.arrivalAirport || '도착공항'}
               </Typography>
             </div>
@@ -126,19 +117,13 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
             </Typography>
           </div>
         )}
-
-        {!compact && (
-          <div className='mt-3'>
-            <Typography variant='body2' className='font-medium text-gray-800'>
-              {data.title}
-            </Typography>
-          </div>
-        )}
       </div>
+
       <div className='relative bg-gradient-to-r from-sky-100 to-sky-50 px-4 py-3'>
+        {/* 점선 구분 */}
+        <div className='absolute left-0 right-0 top-0 border-t-2 border-dashed border-sky-200/40' />
         <div className='flex items-center justify-between'>
           <div className='flex items-center space-x-2'>
-            <IoAirplaneOutline className='h-3 w-3 text-sky-600' />
             <Typography
               variant='caption'
               className='font-semibold tracking-wider text-sky-700'
@@ -146,9 +131,6 @@ export const BoardingPassCard: React.FC<BoardingPassCardProps> = ({
               BOARDING PASS
             </Typography>
           </div>
-          <Typography variant='caption' className='text-sky-600'>
-            ✈️ 여행 계획
-          </Typography>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/travel/detail/move/TransitCard.tsx
+++ b/apps/web/src/components/travel/detail/move/TransitCard.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-import { IoArrowForwardOutline } from 'react-icons/io5';
+import {
+  IoAirplaneOutline,
+  IoArrowForwardOutline,
+  IoBusOutline,
+  IoCarOutline,
+  IoCarSportOutline,
+  IoTrainOutline,
+  IoWalkOutline,
+} from 'react-icons/io5';
 
 import { Typography } from '@ui/components';
 
@@ -26,35 +34,89 @@ export const TransitCard: React.FC<TransitCardProps> = ({
 }) => {
   const color = getBlockColor('move');
 
-  const transportLabelMap: Record<string, string> = {
-    walk: '도보',
-    car: '자동차',
-    bus: '버스',
-    subway: '지하철',
-    taxi: '택시',
-    train: '기차',
-    plane: '비행기',
+  const transportConfig: Record<
+    string,
+    { label: string; icon: React.ReactNode; color: string; bgColor: string }
+  > = {
+    walk: {
+      label: '도보',
+      icon: <IoWalkOutline className='h-4 w-4' />,
+      color: 'text-green-700',
+      bgColor: 'bg-green-100',
+    },
+    car: {
+      label: '자동차',
+      icon: <IoCarOutline className='h-4 w-4' />,
+      color: 'text-blue-700',
+      bgColor: 'bg-blue-100',
+    },
+    bus: {
+      label: '버스',
+      icon: <IoBusOutline className='h-4 w-4' />,
+      color: 'text-orange-700',
+      bgColor: 'bg-orange-100',
+    },
+    subway: {
+      label: '지하철',
+      icon: <IoTrainOutline className='h-4 w-4' />,
+      color: 'text-purple-700',
+      bgColor: 'bg-purple-100',
+    },
+    taxi: {
+      label: '택시',
+      icon: <IoCarSportOutline className='h-4 w-4' />,
+      color: 'text-yellow-700',
+      bgColor: 'bg-yellow-100',
+    },
+    train: {
+      label: '기차',
+      icon: <IoTrainOutline className='h-4 w-4' />,
+      color: 'text-indigo-700',
+      bgColor: 'bg-indigo-100',
+    },
+    plane: {
+      label: '비행기',
+      icon: <IoAirplaneOutline className='h-4 w-4' />,
+      color: 'text-sky-700',
+      bgColor: 'bg-sky-100',
+    },
   };
 
-  const transportLabel = data.transportType
-    ? (transportLabelMap[data.transportType] ?? data.transportType)
-    : undefined;
+  const currentTransport = data.transportType
+    ? transportConfig[data.transportType]
+    : null;
 
   return (
-    <div className={`overflow-hidden rounded-xl border ${color}`}>
-      <div className={`${compact ? 'p-3' : 'p-4'} bg-white`}>
+    <div className='relative overflow-hidden rounded-2xl border border-blue-200/60 bg-gradient-to-br from-blue-50/30 to-white shadow-lg shadow-blue-100/20'>
+      {/* 배경 패턴 */}
+      <div className='absolute inset-0 opacity-5'>
+        <div className='absolute right-4 top-4 text-5xl text-blue-500'>
+          {currentTransport?.icon || <IoArrowForwardOutline />}
+        </div>
+      </div>
+
+      <div
+        className={`relative ${compact ? 'p-4' : 'p-5'} bg-white/80 backdrop-blur-sm`}
+      >
         <div className='flex items-start justify-between'>
-          <div className='flex items-center space-x-2'>
-            <span className='rounded-md bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-700'>
-              {getBlockLabel('move')}
-            </span>
-            {transportLabel && (
-              <Typography
-                variant={compact ? 'caption' : 'body2'}
-                className='text-blue-700'
+          <div className='flex items-center space-x-3'>
+            {currentTransport && (
+              <div
+                className={`rounded-xl px-3 py-2 ${currentTransport.bgColor} flex items-center space-x-2`}
               >
-                {transportLabel}
-              </Typography>
+                {currentTransport.icon}
+                <Typography
+                  variant={compact ? 'caption' : 'body2'}
+                  className={`font-semibold ${currentTransport.color}`}
+                >
+                  {currentTransport.label}
+                </Typography>
+              </div>
+            )}
+            {!currentTransport && (
+              <span className='rounded-md bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-700'>
+                {getBlockLabel('move')}
+              </span>
             )}
           </div>
 
@@ -74,33 +136,71 @@ export const TransitCard: React.FC<TransitCardProps> = ({
           )}
         </div>
 
-        <div
-          className={`mt-3 grid items-center ${compact ? 'gap-2' : 'gap-3'} grid-cols-5`}
-        >
-          <div className='col-span-2'>
-            <Typography variant='caption' className='text-gray-500'>
-              출발
-            </Typography>
-            <Typography
-              variant={compact ? 'body2' : 'body1'}
-              className='truncate font-semibold text-gray-900'
-            >
-              {data.fromAddress ?? '-'}
-            </Typography>
-          </div>
-          <div className='flex items-center justify-center'>
-            <IoArrowForwardOutline className='h-4 w-4 text-blue-400' />
-          </div>
-          <div className='col-span-2 text-right'>
-            <Typography variant='caption' className='text-gray-500'>
-              도착
-            </Typography>
-            <Typography
-              variant={compact ? 'body2' : 'body1'}
-              className='truncate font-semibold text-gray-900'
-            >
-              {data.toAddress ?? '-'}
-            </Typography>
+        <div className={`mt-4 ${compact ? 'space-y-3' : 'space-y-4'}`}>
+          {/* 경로 시각화 */}
+          <div className='relative'>
+            <div className='flex items-center space-x-4'>
+              {/* 출발지 */}
+              <div className='min-w-0 flex-1'>
+                <div className='flex items-center space-x-2'>
+                  <div className='h-3 w-3 flex-shrink-0 rounded-full bg-green-500' />
+                  <div className='min-w-0 flex-1'>
+                    <Typography
+                      variant='caption'
+                      className='font-medium text-green-600'
+                    >
+                      출발
+                    </Typography>
+                    <div title={data.fromAddress}>
+                      <Typography
+                        variant={compact ? 'body2' : 'body1'}
+                        className='truncate font-semibold text-gray-900'
+                      >
+                        {data.fromAddress ||
+                          (data.title ? `${data.title} 출발지` : '출발지')}
+                      </Typography>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* 경로 라인과 아이콘 */}
+              <div className='flex flex-shrink-0 items-center space-x-2'>
+                <div className='h-px w-8 bg-gradient-to-r from-green-300 to-red-300' />
+                <div
+                  className={`rounded-full p-1.5 ${currentTransport?.bgColor || 'bg-blue-100'}`}
+                >
+                  {currentTransport?.icon || (
+                    <IoArrowForwardOutline className='h-3 w-3 text-blue-500' />
+                  )}
+                </div>
+                <div className='h-px w-8 bg-gradient-to-r from-green-300 to-red-300' />
+              </div>
+
+              {/* 도착지 */}
+              <div className='min-w-0 flex-1'>
+                <div className='flex items-center justify-end space-x-2'>
+                  <div className='min-w-0 flex-1 text-right'>
+                    <Typography
+                      variant='caption'
+                      className='font-medium text-red-600'
+                    >
+                      도착
+                    </Typography>
+                    <div title={data.toAddress}>
+                      <Typography
+                        variant={compact ? 'body2' : 'body1'}
+                        className='truncate font-semibold text-gray-900'
+                      >
+                        {data.toAddress ||
+                          (data.title ? `${data.title} 도착지` : '도착지')}
+                      </Typography>
+                    </div>
+                  </div>
+                  <div className='h-3 w-3 flex-shrink-0 rounded-full bg-red-500' />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/apps/web/src/components/travel/detail/move/TransitCard.tsx
+++ b/apps/web/src/components/travel/detail/move/TransitCard.tsx
@@ -32,8 +32,6 @@ export const TransitCard: React.FC<TransitCardProps> = ({
   data,
   compact = false,
 }) => {
-  const color = getBlockColor('move');
-
   const transportConfig: Record<
     string,
     { label: string; icon: React.ReactNode; color: string; bgColor: string }
@@ -87,7 +85,10 @@ export const TransitCard: React.FC<TransitCardProps> = ({
     : null;
 
   return (
-    <div className='relative overflow-hidden rounded-2xl border border-blue-200/60 bg-gradient-to-br from-blue-50/30 to-white shadow-lg shadow-blue-100/20'>
+    <div className='relative overflow-hidden rounded-2xl border border-blue-200/60 shadow-md shadow-blue-100/20'>
+      {/* 내부 그라디언트 레이어 */}
+      <div className='absolute inset-0 bg-gradient-to-br from-blue-50 to-white' />
+
       {/* 배경 패턴 */}
       <div className='absolute inset-0 opacity-5'>
         <div className='absolute right-4 top-4 text-5xl text-blue-500'>
@@ -95,9 +96,7 @@ export const TransitCard: React.FC<TransitCardProps> = ({
         </div>
       </div>
 
-      <div
-        className={`relative ${compact ? 'p-4' : 'p-5'} bg-white/80 backdrop-blur-sm`}
-      >
+      <div className={`relative ${compact ? 'p-4' : 'p-5'}`}>
         <div className='flex items-start justify-between'>
           <div className='flex items-center space-x-3'>
             {currentTransport && (
@@ -147,17 +146,17 @@ export const TransitCard: React.FC<TransitCardProps> = ({
                   <div className='min-w-0 flex-1'>
                     <Typography
                       variant='caption'
-                      className='font-medium text-green-600'
+                      className='font-medium text-blue-500'
                     >
                       출발
                     </Typography>
                     <div title={data.fromAddress}>
                       <Typography
-                        variant={compact ? 'body2' : 'body1'}
-                        className='truncate font-semibold text-gray-900'
+                        variant={compact ? 'body1' : 'h6'}
+                        className='font-bold tracking-wide text-gray-900'
                       >
                         {data.fromAddress ||
-                          (data.title ? `${data.title} 출발지` : '출발지')}
+                          (data.title ? `${data.title}` : '출발지')}
                       </Typography>
                     </div>
                   </div>
@@ -166,7 +165,6 @@ export const TransitCard: React.FC<TransitCardProps> = ({
 
               {/* 경로 라인과 아이콘 */}
               <div className='flex flex-shrink-0 items-center space-x-2'>
-                <div className='h-px w-8 bg-gradient-to-r from-green-300 to-red-300' />
                 <div
                   className={`rounded-full p-1.5 ${currentTransport?.bgColor || 'bg-blue-100'}`}
                 >
@@ -174,7 +172,6 @@ export const TransitCard: React.FC<TransitCardProps> = ({
                     <IoArrowForwardOutline className='h-3 w-3 text-blue-500' />
                   )}
                 </div>
-                <div className='h-px w-8 bg-gradient-to-r from-green-300 to-red-300' />
               </div>
 
               {/* 도착지 */}
@@ -183,17 +180,17 @@ export const TransitCard: React.FC<TransitCardProps> = ({
                   <div className='min-w-0 flex-1 text-right'>
                     <Typography
                       variant='caption'
-                      className='font-medium text-red-600'
+                      className='font-medium text-blue-500'
                     >
                       도착
                     </Typography>
                     <div title={data.toAddress}>
                       <Typography
-                        variant={compact ? 'body2' : 'body1'}
-                        className='truncate font-semibold text-gray-900'
+                        variant={compact ? 'body1' : 'h6'}
+                        className='font-bold tracking-wide text-gray-900'
                       >
                         {data.toAddress ||
-                          (data.title ? `${data.title} 도착지` : '도착지')}
+                          (data.title ? `${data.title}` : '도착지')}
                       </Typography>
                     </div>
                   </div>

--- a/apps/web/src/components/travel/index.ts
+++ b/apps/web/src/components/travel/index.ts
@@ -1,5 +1,6 @@
 // 여행 계획 관련 컴포넌트
 export { default as TravelBasicInfoModal } from './modals/TravelBasicInfoModal';
+export { default as TravelEditInfoModal } from './modals/TravelEditInfoModal';
 export { default as LocationInput } from './inputs/LocationInput';
 export { default as TravelDatePicker } from './inputs/TravelDatePicker';
 

--- a/apps/web/src/components/travel/index.ts
+++ b/apps/web/src/components/travel/index.ts
@@ -1,6 +1,7 @@
 // 여행 계획 관련 컴포넌트
 export { default as TravelBasicInfoModal } from './modals/TravelBasicInfoModal';
 export { default as TravelEditInfoModal } from './modals/TravelEditInfoModal';
+export { default as TravelActivitiesModal } from './modals/TravelActivitiesModal';
 export { default as LocationInput } from './inputs/LocationInput';
 export { default as TravelDatePicker } from './inputs/TravelDatePicker';
 

--- a/apps/web/src/components/travel/inputs/TimeRangePicker.tsx
+++ b/apps/web/src/components/travel/inputs/TimeRangePicker.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import React from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { IoChevronDownOutline, IoTimeOutline } from 'react-icons/io5';
+
+import { Typography } from '@ui/components';
+import { cn } from '@ui/utils/cn';
+
+type TimeRangePickerProps = {
+  label?: string;
+  startTime: string; // HH:MM
+  endTime: string; // HH:MM
+  onStartTimeChange: (time: string) => void;
+  onEndTimeChange: (time: string) => void;
+  suggestedDuration?: number; // 분 단위
+  disabled?: boolean;
+  className?: string;
+  errorText?: string;
+  helperText?: string;
+};
+
+const pad = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+const toMinutes = (hhmm?: string) => {
+  if (!hhmm) return undefined;
+  const [h, m] = hhmm.split(':').map(Number);
+  if (Number.isNaN(h) || Number.isNaN(m)) return undefined;
+  return h * 60 + m;
+};
+const toHHMM = (mins?: number) => {
+  if (mins === undefined) return '';
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return `${pad(h)}:${pad(m)}`;
+};
+
+const QUICK_PRESETS = [30, 60, 90, 120];
+const nowHHMM = () => {
+  const d = new Date();
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+const next30MinHHMM = () => {
+  const d = new Date();
+  const mins = d.getMinutes();
+  const add = 30 - (mins % 30 || 30);
+  d.setMinutes(mins + add);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+const TimeRangePicker: React.FC<TimeRangePickerProps> = ({
+  label = '시간',
+  startTime,
+  endTime,
+  onStartTimeChange,
+  onEndTimeChange,
+  suggestedDuration = 0,
+  disabled,
+  className,
+  errorText,
+  helperText,
+}) => {
+  const [open, setOpen] = React.useState(false);
+  const [focused, setFocused] = React.useState<'start' | 'end' | null>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const isError = !!errorText;
+  const startMins = toMinutes(startTime);
+  const endMins = toMinutes(endTime);
+  const hasBoth = startMins !== undefined && endMins !== undefined;
+  const duration = hasBoth ? endMins! - startMins! : undefined;
+  const showSuggestion = Boolean(
+    startMins !== undefined &&
+      suggestedDuration > 0 &&
+      (endMins === undefined || endMins <= startMins)
+  );
+
+  React.useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setFocused(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const applySuggested = () => {
+    if (startMins === undefined || suggestedDuration <= 0) return;
+    onEndTimeChange(toHHMM(startMins + suggestedDuration));
+    setOpen(false);
+    setFocused(null);
+  };
+
+  const applyPreset = (mins: number) => {
+    if (startMins === undefined) return;
+    onEndTimeChange(toHHMM(startMins + mins));
+    setOpen(false);
+    setFocused(null);
+  };
+
+  return (
+    <div className={cn('w-full', className)} ref={containerRef}>
+      {label && (
+        <label className='mb-1.5 block text-sm font-medium text-gray-700'>
+          {label}
+        </label>
+      )}
+
+      <div
+        className={cn(
+          'relative flex w-full items-center rounded-2xl bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-black/5',
+          isError
+            ? 'ring-red-500 focus-within:ring-2 focus-within:ring-red-500'
+            : 'focus-within:ring-2 focus-within:ring-sky-300',
+          disabled ? 'cursor-not-allowed bg-gray-50 opacity-70' : 'cursor-text'
+        )}
+        onClick={() => {
+          if (!disabled) {
+            setOpen((v) => !v);
+            setFocused('start');
+          }
+        }}
+      >
+        <IoTimeOutline className='mr-3 h-5 w-5 text-gray-400' />
+        <div className='grid flex-1 grid-cols-[1fr_auto_1fr] items-center gap-3'>
+          <input
+            type='time'
+            value={startTime}
+            onChange={(e) => onStartTimeChange(e.target.value)}
+            onFocus={() => setFocused('start')}
+            className='w-full rounded-xl border-0 bg-transparent p-0 text-gray-900 outline-none focus:outline-none'
+            disabled={disabled}
+          />
+          <span className='select-none text-gray-400'>~</span>
+          <input
+            type='time'
+            value={endTime}
+            onChange={(e) => onEndTimeChange(e.target.value)}
+            onFocus={() => setFocused('end')}
+            className='w-full rounded-xl border-0 bg-transparent p-0 text-gray-900 outline-none focus:outline-none'
+            disabled={disabled}
+          />
+        </div>
+        <IoChevronDownOutline
+          className={cn(
+            'ml-3 h-5 w-5 text-gray-400 transition-transform',
+            open && 'rotate-180'
+          )}
+        />
+      </div>
+
+      <AnimatePresence>
+        {open && !disabled && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.15 }}
+            className='mt-2 rounded-2xl border border-gray-200 bg-white p-3 shadow-lg'
+          >
+            {startMins === undefined ? (
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='select-none text-xs text-gray-500'>
+                  시작 시간을 먼저 선택하세요
+                </span>
+                <button
+                  type='button'
+                  onClick={() => onStartTimeChange(nowHHMM())}
+                  className='rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50'
+                >
+                  지금으로 설정
+                </button>
+                <button
+                  type='button'
+                  onClick={() => onStartTimeChange(next30MinHHMM())}
+                  className='rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50'
+                >
+                  다음 30분으로 설정
+                </button>
+              </div>
+            ) : (
+              <>
+                {/* 추천 길이 안내 및 적용 */}
+                {showSuggestion && (
+                  <div className='mb-2 flex items-center justify-between rounded-xl bg-sky-50 p-3'>
+                    <div>
+                      <Typography
+                        variant='body2'
+                        className='font-medium text-sky-900'
+                      >
+                        추천 소요시간 적용 ({suggestedDuration}분)
+                      </Typography>
+                      <Typography variant='caption' className='text-sky-700'>
+                        시작 시간 기준으로 종료 시간을 자동 설정합니다
+                      </Typography>
+                    </div>
+                    <button
+                      type='button'
+                      onClick={applySuggested}
+                      className='rounded-lg bg-sky-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-sky-600'
+                    >
+                      적용
+                    </button>
+                  </div>
+                )}
+
+                {/* 빠른 선택 프리셋 */}
+                <div className='flex flex-wrap items-center gap-2'>
+                  <span className='select-none text-xs text-gray-500'>
+                    빠른 선택
+                  </span>
+                  {QUICK_PRESETS.map((m) => (
+                    <button
+                      key={m}
+                      type='button'
+                      onClick={() => applyPreset(m)}
+                      className='rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50'
+                    >
+                      +{m}분
+                    </button>
+                  ))}
+                  {hasBoth && duration !== undefined && (
+                    <span className='ml-auto select-none text-xs text-gray-500'>
+                      현재 소요시간: {duration}분
+                    </span>
+                  )}
+                </div>
+              </>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {helperText && !errorText && (
+        <p className='mt-1.5 text-xs text-gray-500'>{helperText}</p>
+      )}
+      {errorText && <p className='mt-1.5 text-xs text-red-500'>{errorText}</p>}
+    </div>
+  );
+};
+
+export default TimeRangePicker;

--- a/apps/web/src/components/travel/modals/TravelActivitiesModal.tsx
+++ b/apps/web/src/components/travel/modals/TravelActivitiesModal.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import React from 'react';
+
+import { IoTimeOutline } from 'react-icons/io5';
+
+import { Avatar, Typography } from '@ui/components';
+
+import { Modal } from '@/components/basic';
+
+interface ActivityItem {
+  id: string;
+  type:
+    | 'block_add'
+    | 'block_edit'
+    | 'block_delete'
+    | 'block_move'
+    | 'comment'
+    | 'participant_join';
+  user: {
+    id: string;
+    nickname: string;
+    profile_image_url?: string;
+  };
+  content: string;
+  timestamp: string;
+  blockId?: string;
+  blockTitle?: string;
+}
+
+interface TravelActivitiesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activities: ActivityItem[];
+  travelTitle: string;
+  onBlockClick?: (blockId: string) => void;
+}
+
+const TravelActivitiesModal: React.FC<TravelActivitiesModalProps> = ({
+  isOpen,
+  onClose,
+  activities,
+  travelTitle,
+  onBlockClick,
+}) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`${travelTitle} - 전체 활동 내역`}
+      width='responsive'
+    >
+      <div className='flex flex-col'>
+        <div className='max-h-[70vh] overflow-y-auto px-6 py-6'>
+          {activities.length === 0 ? (
+            <div className='py-12 text-center'>
+              <Typography variant='body1' className='text-gray-500'>
+                아직 활동 내역이 없습니다.
+              </Typography>
+            </div>
+          ) : (
+            <div className='space-y-4'>
+              {activities.map((activity: ActivityItem) => (
+                <div
+                  key={activity.id}
+                  className={`rounded-lg border border-gray-200 p-4 transition-all duration-200 ${
+                    activity.blockId
+                      ? 'cursor-pointer hover:border-blue-300 hover:bg-blue-50 hover:shadow-sm'
+                      : 'hover:border-gray-300 hover:shadow-sm'
+                  }`}
+                  onClick={() => {
+                    if (activity.blockId && onBlockClick) {
+                      onBlockClick(activity.blockId);
+                      onClose(); // 모달 닫기
+                    }
+                  }}
+                >
+                  <div className='flex items-start space-x-4'>
+                    <Avatar
+                      src={activity.user.profile_image_url}
+                      alt={activity.user.nickname}
+                      size='medium'
+                    />
+                    <div className='flex-1'>
+                      <div className='mb-2 flex items-center space-x-2'>
+                        <Typography
+                          variant='body1'
+                          className='font-semibold text-gray-900'
+                        >
+                          {activity.user.nickname}
+                        </Typography>
+                        <div className='flex items-center space-x-1'>
+                          <IoTimeOutline className='h-3 w-3 text-gray-400' />
+                          <Typography
+                            variant='caption'
+                            className='text-gray-400'
+                          >
+                            {new Date(activity.timestamp).toLocaleString(
+                              'ko-KR',
+                              {
+                                year: 'numeric',
+                                month: 'short',
+                                day: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit',
+                              }
+                            )}
+                          </Typography>
+                        </div>
+                      </div>
+                      <Typography variant='body2' className='text-gray-700'>
+                        {activity.content}
+                      </Typography>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default TravelActivitiesModal;

--- a/apps/web/src/components/travel/modals/TravelBasicInfoModal.tsx
+++ b/apps/web/src/components/travel/modals/TravelBasicInfoModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { IoPersonOutline, IoWalletOutline } from 'react-icons/io5';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -45,6 +46,7 @@ const TravelBasicInfoModal: React.FC<TravelBasicInfoModalProps> = ({
   const router = useRouter();
   const toast = useToast();
   const supabase = createClient();
+  const queryClient = useQueryClient();
 
   const [loading, setLoading] = useState(false);
   const [basicInfo, setBasicInfo] = useState<TravelBasicInfo>({
@@ -252,6 +254,17 @@ const TravelBasicInfoModal: React.FC<TravelBasicInfoModalProps> = ({
       }
       toast.success('여행 계획이 생성되었습니다!');
       onClose();
+      // 목록 즉시 반영: 관련 쿼리 무효화
+      try {
+        queryClient.invalidateQueries({
+          queryKey: ['accessible-travel-plans'],
+        });
+        queryClient.invalidateQueries({ queryKey: ['invited-travel-plans'] });
+        queryClient.invalidateQueries({ queryKey: ['upcoming-travel'] });
+        queryClient.invalidateQueries({ queryKey: ['recent-activities'] });
+      } catch (error) {
+        console.error('Failed to invalidate queries:', error);
+      }
       router.push('/');
     } catch {
       toast.error('여행 계획 생성 중 오류가 발생했습니다.');

--- a/apps/web/src/components/travel/modals/TravelEditInfoModal.tsx
+++ b/apps/web/src/components/travel/modals/TravelEditInfoModal.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { IoWalletOutline } from 'react-icons/io5';
+
+import { Button, Input, Typography } from '@ui/components';
+
+import { Modal } from '@/components/basic';
+import { countriesISO } from '@/components/travel/constants/countries';
+import LocationInput from '@/components/travel/inputs/LocationInput';
+import TravelDatePicker from '@/components/travel/inputs/TravelDatePicker';
+import { useSession } from '@/hooks/useSession';
+import { useToast } from '@/hooks/useToast';
+import {
+  convertCurrency,
+  formatCurrencyWithExchange,
+  getCurrencyByDestination,
+  getCurrencyByNationality,
+} from '@/lib/exchange-rate';
+import { createClient } from '@/lib/supabase/client/supabase';
+
+interface TravelInfo {
+  title: string;
+  location: string;
+  startDate: Date | null;
+  endDate: Date | null;
+  targetBudget: string;
+}
+
+interface TravelPlan {
+  id: string;
+  title: string;
+  location: string;
+  start_date: string;
+  end_date: string;
+  target_budget?: number;
+  budget_currency?: string;
+  destination_country?: string;
+}
+
+interface TravelEditInfoModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  travelPlan: TravelPlan;
+  onUpdate?: () => void;
+}
+
+const TravelEditInfoModal: React.FC<TravelEditInfoModalProps> = ({
+  isOpen,
+  onClose,
+  travelPlan,
+  onUpdate,
+}) => {
+  const { userProfile } = useSession();
+  const toast = useToast();
+  const supabase = createClient();
+
+  const [loading, setLoading] = useState(false);
+  const [travelInfo, setTravelInfo] = useState<TravelInfo>({
+    title: '',
+    location: '',
+    startDate: null,
+    endDate: null,
+    targetBudget: '',
+  });
+
+  const [errors, setErrors] = useState<{
+    title?: string;
+    location?: string;
+    dates?: string;
+    budget?: string;
+  }>({});
+
+  // 초기 데이터 설정
+  useEffect(() => {
+    if (travelPlan && isOpen) {
+      setTravelInfo({
+        title: travelPlan.title,
+        location: travelPlan.location,
+        startDate: new Date(travelPlan.start_date),
+        endDate: new Date(travelPlan.end_date),
+        targetBudget: travelPlan.target_budget
+          ? formatBudgetInput(travelPlan.target_budget.toString())
+          : '',
+      });
+    }
+  }, [travelPlan, isOpen]);
+
+  // 사용자 통화 가져오기
+  const getUserCurrency = () => {
+    return getCurrencyByNationality(userProfile?.nationality);
+  };
+
+  // 목적지 통화 가져오기
+  const getDestinationCurrency = () => {
+    if (!travelInfo.location) return getUserCurrency();
+
+    const selectedCountry = countriesISO.find(
+      (country) =>
+        country.nameKo.toLowerCase() === travelInfo.location.toLowerCase() ||
+        country.nameEn.toLowerCase() === travelInfo.location.toLowerCase()
+    );
+
+    return getCurrencyByDestination(selectedCountry?.code);
+  };
+
+  // 예산 입력 포맷팅 (천 단위 구분자 추가)
+  const formatBudgetInput = (value: string) => {
+    // 숫자가 아닌 문자 제거
+    const numericValue = value.replace(/[^\d]/g, '');
+
+    // 천 단위 구분자 추가
+    if (numericValue) {
+      return parseInt(numericValue).toLocaleString('ko-KR');
+    }
+    return '';
+  };
+
+  // 환율 적용된 목적지 통화 예산 미리보기
+  const [convertedBudget, setConvertedBudget] = useState<number | null>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      const amount = parseBudgetValue(travelInfo.targetBudget);
+      const userCur = getUserCurrency();
+      const destCur = getDestinationCurrency();
+      if (!amount || !destCur) {
+        setConvertedBudget(null);
+        return;
+      }
+      try {
+        const v = await convertCurrency(amount, userCur, destCur);
+        setConvertedBudget(v);
+      } catch {
+        setConvertedBudget(null);
+      }
+    };
+    run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [travelInfo.targetBudget, travelInfo.location, userProfile?.nationality]);
+
+  // 실제 숫자값으로 변환
+  const parseBudgetValue = (formattedValue: string): number => {
+    return parseInt(formattedValue.replace(/[^\d]/g, '')) || 0;
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {};
+    if (!travelInfo.title.trim()) {
+      newErrors.title = '여행 제목을 입력해주세요.';
+    } else if (travelInfo.title.trim().length > 50) {
+      newErrors.title = '여행 제목은 50자 이내로 입력해주세요.';
+    }
+    if (!travelInfo.location.trim()) {
+      newErrors.location = '나라(국가)를 입력해주세요.';
+    } else {
+      const normalize = (s: string) => s.trim().toLowerCase();
+      const input = normalize(travelInfo.location);
+      const isValidCountry = countriesISO.some(
+        (c) => normalize(c.nameKo) === input || normalize(c.nameEn) === input
+      );
+      if (!isValidCountry) {
+        newErrors.location = '국가 목록에서 정확한 국가를 선택해주세요.';
+      }
+    }
+    if (!travelInfo.startDate || !travelInfo.endDate) {
+      newErrors.dates = '여행 시작일과 종료일을 선택해주세요.';
+    }
+
+    // 예산 검증 (선택사항이지만 입력 시 유효성 검사)
+    if (travelInfo.targetBudget) {
+      const budgetValue = parseBudgetValue(travelInfo.targetBudget);
+      if (budgetValue <= 0) {
+        newErrors.budget = '예산은 0보다 큰 값을 입력해주세요.';
+      } else if (budgetValue > 1000000000) {
+        // 10억 제한
+        newErrors.budget = '예산이 너무 큽니다. 더 작은 값을 입력해주세요.';
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleUpdateTrip = async () => {
+    if (!validateForm()) {
+      toast.error('입력 정보를 확인해주세요.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const budgetValue = parseBudgetValue(travelInfo.targetBudget);
+      const userCurrency = getUserCurrency();
+      const destinationCurrency = getDestinationCurrency();
+
+      // 목적지 국가 코드 찾기
+      const selectedCountry = countriesISO.find(
+        (country) =>
+          country.nameKo.toLowerCase() === travelInfo.location.toLowerCase() ||
+          country.nameEn.toLowerCase() === travelInfo.location.toLowerCase()
+      );
+
+      // 목적지 선택됨 → 예산을 목적지 통화로 변환하여 저장
+      const budgetToSave = destinationCurrency
+        ? await convertCurrency(budgetValue, userCurrency, destinationCurrency)
+        : budgetValue;
+
+      const budgetCurrencyToSave = destinationCurrency || userCurrency;
+
+      const updateData = {
+        title: travelInfo.title.trim(),
+        location: travelInfo.location.trim(),
+        start_date: travelInfo.startDate!.toISOString().split('T')[0],
+        end_date: travelInfo.endDate!.toISOString().split('T')[0],
+        target_budget: budgetValue > 0 ? budgetToSave : 0,
+        budget_currency: budgetCurrencyToSave,
+        destination_country: selectedCountry?.code,
+      };
+
+      const response = await fetch(`/api/travel/${travelPlan.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || '여행 계획 수정에 실패했습니다.');
+      }
+
+      toast.success('여행 계획이 수정되었습니다!');
+      onUpdate?.();
+      onClose();
+    } catch (error: any) {
+      toast.error(error.message || '여행 계획 수정 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const canProceed =
+    travelInfo.title.trim() &&
+    travelInfo.location.trim() &&
+    travelInfo.startDate &&
+    travelInfo.endDate;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title='여행 정보 수정'
+      width='responsive'
+    >
+      <div className='flex flex-col'>
+        <div className='max-h-[70vh] overflow-y-auto px-6 py-6'>
+          <div className='space-y-8'>
+            <div className='space-y-4'>
+              <Input
+                label='여행 제목'
+                placeholder='예: 제주도 힐링 여행, 유럽 배낭여행'
+                value={travelInfo.title}
+                onChange={(e) => {
+                  setTravelInfo((prev) => ({ ...prev, title: e.target.value }));
+                  if (errors.title)
+                    setErrors((prev) => ({ ...prev, title: undefined }));
+                }}
+                errorText={errors.title}
+                maxLength={50}
+              />
+              <LocationInput
+                label='나라(국가)'
+                placeholder='예: 대한민국 / United States'
+                helperText='국가만 선택할 수 있어요'
+                value={travelInfo.location}
+                onChange={(value) => {
+                  setTravelInfo((prev) => ({ ...prev, location: value }));
+                  if (errors.location)
+                    setErrors((prev) => ({ ...prev, location: undefined }));
+                }}
+                errorText={errors.location}
+              />
+              <TravelDatePicker
+                label='여행 기간'
+                startDate={travelInfo.startDate}
+                endDate={travelInfo.endDate}
+                onDateChange={(
+                  startDate: Date | null,
+                  endDate: Date | null
+                ) => {
+                  setTravelInfo((prev) => ({ ...prev, startDate, endDate }));
+                  if (errors.dates)
+                    setErrors((prev) => ({ ...prev, dates: undefined }));
+                }}
+                errorText={errors.dates}
+              />
+
+              <div className='space-y-3'>
+                <div>
+                  <label className='mb-2 flex items-center space-x-2 text-sm font-medium text-gray-700'>
+                    <IoWalletOutline className='h-4 w-4' />
+                    <span>예산 (선택사항)</span>
+                  </label>
+                  <Input
+                    placeholder={`예: ${formatCurrencyWithExchange(1000000, getUserCurrency())}`}
+                    value={travelInfo.targetBudget}
+                    onChange={(e) => {
+                      const formattedValue = formatBudgetInput(e.target.value);
+                      setTravelInfo((prev) => ({
+                        ...prev,
+                        targetBudget: formattedValue,
+                      }));
+                      if (errors.budget)
+                        setErrors((prev) => ({ ...prev, budget: undefined }));
+                    }}
+                    errorText={errors.budget}
+                    helperText={(function () {
+                      const ownerName = userProfile?.nationality || '대한민국';
+                      const destName = travelInfo.location;
+                      if (destName) {
+                        return `💡 지금은 ${ownerName} 화폐 단위로 입력해주세요.`;
+                      }
+                      return `💡 지금은 ${ownerName} 화폐 단위로 입력해주세요.`;
+                    })()}
+                  />
+                </div>
+
+                {travelInfo.targetBudget && (
+                  <div className='rounded-lg border border-blue-200 bg-blue-50 p-4'>
+                    <div className='flex items-center space-x-2'>
+                      <IoWalletOutline className='h-5 w-5 text-blue-600' />
+                      <div>
+                        <Typography
+                          variant='body2'
+                          className='font-semibold text-blue-800'
+                        >
+                          설정된 예산 (목적지 통화)
+                        </Typography>
+                        <Typography
+                          variant='h6'
+                          className='font-bold text-blue-900'
+                        >
+                          {(() => {
+                            const userCur = getUserCurrency();
+                            const destCur = getDestinationCurrency();
+                            const amount = parseBudgetValue(
+                              travelInfo.targetBudget
+                            );
+                            if (!amount)
+                              return formatCurrencyWithExchange(0, destCur);
+                            if (destCur) {
+                              const val = convertedBudget ?? amount;
+                              return formatCurrencyWithExchange(val, destCur);
+                            }
+                            return formatCurrencyWithExchange(amount, userCur);
+                          })()}
+                        </Typography>
+                        <Typography variant='caption' className='text-blue-700'>
+                          기준 입력:{' '}
+                          {formatCurrencyWithExchange(
+                            parseBudgetValue(travelInfo.targetBudget),
+                            getUserCurrency()
+                          )}
+                        </Typography>
+                        {travelInfo.location &&
+                          getDestinationCurrency() !== getUserCurrency() && (
+                            <Typography
+                              variant='caption'
+                              className='text-blue-600'
+                            >
+                              ※ 저장 시 목적지 통화로 환율 변환되어 저장됩니다
+                            </Typography>
+                          )}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className='flex space-x-3 border-t px-6 py-4'>
+          <Button
+            variant='outlined'
+            colorTheme='gray'
+            onClick={onClose}
+            className='flex-1'
+          >
+            취소
+          </Button>
+          <Button
+            variant='filled'
+            colorTheme='blue'
+            onClick={handleUpdateTrip}
+            disabled={!canProceed || loading}
+            className='flex-1'
+          >
+            {loading ? '수정 중...' : '수정하기'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default TravelEditInfoModal;

--- a/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
+++ b/apps/web/src/components/travel/overview/InvitedTravelWidget.tsx
@@ -1,18 +1,23 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
 import { IoCalendarOutline, IoPeopleOutline } from 'react-icons/io5';
 
-import { Typography } from '@ui/components';
+import { Button, Typography } from '@ui/components';
 
+import { Modal } from '@/components/basic/Modal';
 import { useInvitedTravelPlans } from '@/hooks/useTravelPlans';
 
 const InvitedTravelWidget: React.FC = () => {
-  const { data: plans = [], isLoading } = useInvitedTravelPlans(5);
+  const { data: plans = [], isLoading } = useInvitedTravelPlans(10); // 더 많은 데이터를 가져옴
   const router = useRouter();
+  const [showAllModal, setShowAllModal] = useState(false);
+
+  const displayedPlans = plans.slice(0, 3); // 처음 3개만 표시
+  const hasMorePlans = plans.length > 3;
 
   if (isLoading) {
     return (
@@ -37,23 +42,23 @@ const InvitedTravelWidget: React.FC = () => {
 
   return (
     <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
-      <Typography variant='h6' weight='semiBold' className='mb-4 text-gray-900'>
+      <Typography variant='h5' weight='semiBold' className='mb-4 text-gray-900'>
         📩 초대받은 여행
       </Typography>
 
       {plans.length === 0 ? (
-        <div className='py-8 text-center'>
+        <div className='flex flex-col items-center justify-center py-16 text-center'>
           <div className='mb-2 text-4xl'>🗺️</div>
           <Typography variant='body2' className='mb-1 text-gray-500'>
             초대받은 여행이 없습니다
           </Typography>
           <Typography variant='caption' className='text-gray-400'>
-            초대 링크를 받거나 공유된 여행에 참여해 보세요
+            초대 링크를 받거나 공유된 여행에 만들어 보세요
           </Typography>
         </div>
       ) : (
         <div className='space-y-3'>
-          {plans.map((plan) => {
+          {displayedPlans.map((plan) => {
             const start = new Date(plan.start_date).toLocaleDateString(
               'ko-KR',
               {
@@ -113,6 +118,106 @@ const InvitedTravelWidget: React.FC = () => {
           })}
         </div>
       )}
+
+      {hasMorePlans && (
+        <div className='mt-4 border-t border-gray-100 pt-4'>
+          <button
+            className='w-full text-center text-sm font-medium text-blue-600 transition-colors hover:text-blue-700'
+            onClick={() => setShowAllModal(true)}
+          >
+            모든 초대받은 여행 보기 ({plans.length}개)
+          </button>
+        </div>
+      )}
+
+      {/* 모든 초대받은 여행 모달 */}
+      <Modal
+        isOpen={showAllModal}
+        onClose={() => setShowAllModal(false)}
+        width='responsive'
+      >
+        <div className='p-4 sm:p-6'>
+          <Typography
+            variant='h5'
+            weight='semiBold'
+            className='mb-4 text-gray-900'
+          >
+            📩 초대받은 여행 ({plans.length}개)
+          </Typography>
+          <div className='max-h-[60vh] space-y-3 overflow-y-auto sm:max-h-96'>
+            {plans.map((plan) => {
+              const start = new Date(plan.start_date).toLocaleDateString(
+                'ko-KR',
+                {
+                  month: 'short',
+                  day: 'numeric',
+                }
+              );
+              const end = new Date(plan.end_date).toLocaleDateString('ko-KR', {
+                month: 'short',
+                day: 'numeric',
+              });
+              return (
+                <div
+                  key={plan.id}
+                  onClick={() => {
+                    router.push(`/travel/${plan.id}`);
+                    setShowAllModal(false);
+                  }}
+                  className='flex cursor-pointer items-start space-x-3 rounded-lg p-3 transition-colors hover:bg-gray-50'
+                >
+                  <div className='flex h-8 w-8 items-center justify-center rounded-full bg-blue-50 text-blue-600'>
+                    <IoPeopleOutline className='h-4 w-4' />
+                  </div>
+                  <div className='min-w-0 flex-1'>
+                    <div className='mb-1 flex items-center justify-between gap-2'>
+                      <Typography
+                        variant='body2'
+                        className='truncate text-gray-900'
+                      >
+                        {plan.title}
+                      </Typography>
+                      <span className='whitespace-nowrap rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600'>
+                        {plan.role === 'owner'
+                          ? '소유자'
+                          : plan.role === 'editor'
+                            ? '편집자'
+                            : '읽기'}
+                      </span>
+                    </div>
+                    <Typography
+                      variant='caption'
+                      className='mb-1 block text-gray-600'
+                    >
+                      {plan.location}
+                    </Typography>
+                    <div className='flex items-center justify-between text-gray-500'>
+                      <div className='flex items-center gap-1'>
+                        <IoCalendarOutline className='h-3.5 w-3.5' />
+                        <Typography variant='caption'>
+                          {start} - {end}
+                        </Typography>
+                      </div>
+                      <Typography variant='caption'>
+                        {plan.participantCount}명
+                      </Typography>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className='mt-6 flex justify-end border-t border-gray-100 pt-4'>
+            <Button
+              variant='outlined'
+              onClick={() => setShowAllModal(false)}
+              className='w-full sm:w-auto'
+            >
+              닫기
+            </Button>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/apps/web/src/components/travel/overview/TravelPlansList.tsx
+++ b/apps/web/src/components/travel/overview/TravelPlansList.tsx
@@ -270,9 +270,6 @@ const TravelPlansList: React.FC = () => {
   return (
     <div className='space-y-6'>
       <div>
-        <Typography variant='h4' weight='bold' className='mb-6 text-gray-900'>
-          여행 계획 목록
-        </Typography>
         <div className='flex flex-col space-y-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0'>
           <div className='flex space-x-2'>
             {filterOptions.map((option) => (

--- a/apps/web/src/hooks/useBlocks.ts
+++ b/apps/web/src/hooks/useBlocks.ts
@@ -305,6 +305,7 @@ export const useBlocks = ({
           end_time: request.timeRange?.endTime,
           cost: request.cost?.amount,
           currency: request.cost?.currency,
+          meta: request.meta,
         }),
       });
 

--- a/apps/web/src/hooks/useTravelDetail.ts
+++ b/apps/web/src/hooks/useTravelDetail.ts
@@ -8,7 +8,7 @@ import {
   type MoveBlockRequest,
   type TravelDetailResponse,
   updateBlock,
-  type UpdateBlockRequest,
+  type UpdateBlockData,
 } from '@/lib/api/travel';
 import { createClient } from '@/lib/supabase/client/supabase';
 
@@ -79,7 +79,7 @@ export function useUpdateBlock() {
       data,
     }: {
       blockId: string;
-      data: UpdateBlockRequest;
+      data: UpdateBlockData;
     }) => updateBlock(blockId, data),
     onSuccess: (updatedBlock) => {
       // 여행 상세 정보 캐시 업데이트

--- a/apps/web/src/lib/api/travel.ts
+++ b/apps/web/src/lib/api/travel.ts
@@ -70,26 +70,66 @@ export interface CreateBlockRequest {
   title: string;
   description?: string;
   day_number: number;
-  order_index: number;
+  order_index?: number;
   block_type?: string;
-  location?: string;
+  location?:
+    | string
+    | {
+        address: string;
+        latitude?: number;
+        longitude?: number;
+        placeId?: string;
+      };
   start_time?: string;
   end_time?: string;
   cost?: number;
   currency?: string;
+  meta?: Record<string, unknown>;
 }
 
 export interface UpdateBlockRequest {
+  id: string;
+  plan_id?: string;
   title?: string;
   description?: string;
   day_number?: number;
   order_index?: number;
   block_type?: string;
-  location?: string;
+  location?:
+    | string
+    | {
+        address: string;
+        latitude?: number;
+        longitude?: number;
+        placeId?: string;
+      };
   start_time?: string;
   end_time?: string;
   cost?: number;
   currency?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface UpdateBlockData {
+  plan_id?: string;
+  title?: string;
+  description?: string;
+  day_number?: number;
+  order_index?: number;
+  block_type?: string;
+  location?:
+    | string
+    | {
+        address: string;
+        latitude?: number;
+        longitude?: number;
+        placeId?: string;
+      };
+  start_time?: string;
+  end_time?: string;
+  cost?: number;
+  currency?: string;
+  meta?: Record<string, unknown>;
 }
 
 export interface MoveBlockRequest {
@@ -136,9 +176,28 @@ export async function createBlock(
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    console.error('[createBlock] failed', { status: response.status, error });
-    throw new Error(error.error || 'Failed to create block');
+    let parsed: any = {};
+    try {
+      parsed = await response.json();
+    } catch {
+      try {
+        const text = await response.text();
+        parsed = { raw: text };
+      } catch {
+        parsed = {};
+      }
+    }
+    console.error('[createBlock] failed', {
+      status: response.status,
+      statusText: response.statusText,
+      error: parsed,
+    });
+    const message =
+      parsed?.error ||
+      parsed?.details ||
+      parsed?.hint ||
+      'Failed to create block';
+    throw new Error(message);
   }
 
   const json = (await response.json()) as TravelBlock;
@@ -147,7 +206,7 @@ export async function createBlock(
 
 export async function updateBlock(
   blockId: string,
-  data: UpdateBlockRequest
+  data: UpdateBlockData
 ): Promise<TravelBlock> {
   const response = await fetch(`/api/blocks/${blockId}`, {
     method: 'PUT',
@@ -158,10 +217,18 @@ export async function updateBlock(
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
+    let error: any = {};
+    let errorText = '';
+    try {
+      error = await response.json();
+    } catch (e) {
+      errorText = await response.text();
+    }
     console.error('[updateBlock] failed', {
       status: response.status,
+      statusText: response.statusText,
       error,
+      errorText,
       blockId,
     });
     throw new Error(error.error || 'Failed to update block');
@@ -180,9 +247,28 @@ export async function deleteBlock(blockId: string): Promise<void> {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    console.error('[deleteBlock] failed', { status: response.status, error });
-    throw new Error(error.error || 'Failed to delete block');
+    let parsed: any = {};
+    try {
+      parsed = await response.json();
+    } catch {
+      try {
+        const text = await response.text();
+        parsed = { raw: text };
+      } catch {
+        parsed = {};
+      }
+    }
+    console.error('[deleteBlock] failed', {
+      status: response.status,
+      statusText: response.statusText,
+      error: parsed,
+    });
+    const message =
+      parsed?.error ||
+      parsed?.details ||
+      parsed?.hint ||
+      'Failed to delete block';
+    throw new Error(message);
   }
 }
 

--- a/apps/web/src/lib/api/travel.ts
+++ b/apps/web/src/lib/api/travel.ts
@@ -32,6 +32,7 @@ export interface TravelBlock {
   end_time?: string;
   cost?: number;
   currency?: string;
+  meta?: Record<string, unknown>;
   created_by: string;
   created_at: string;
   updated_at: string;

--- a/apps/web/src/lib/block-helpers.ts
+++ b/apps/web/src/lib/block-helpers.ts
@@ -1,0 +1,357 @@
+/**
+ * 블록 생성 관련 헬퍼 함수들
+ * 통화 로직, 시간 계산, 공항 제안 등의 스마트 기능
+ */
+import { CURRENCIES, CurrencyCode } from '@/lib/currency';
+import { BlockType } from '@/types/travel/blocks';
+
+// 사용자 국적별 기본 통화 매핑
+const NATIONALITY_CURRENCY_MAP: Record<string, CurrencyCode> = {
+  KR: 'KRW',
+  US: 'USD',
+  JP: 'JPY',
+  CN: 'CNY',
+  GB: 'GBP',
+  EU: 'EUR',
+  TH: 'THB',
+  VN: 'VND',
+  TW: 'TWD',
+  HK: 'HKD',
+  SG: 'SGD',
+  MY: 'MYR',
+  PH: 'PHP',
+  ID: 'IDR',
+  AU: 'AUD',
+  CA: 'CAD',
+};
+
+/**
+ * 사용자 국적에 따른 통화 반환
+ */
+export const getCurrencyFromNationality = (
+  nationality?: string
+): CurrencyCode => {
+  if (!nationality) return 'KRW';
+  return NATIONALITY_CURRENCY_MAP[nationality.toUpperCase()] || 'KRW';
+};
+
+/**
+ * 블록 타입별 기본 통화 결정 로직
+ * 항공료는 출발국(사용자 국적) 기준, 나머지는 목적지 기준
+ */
+export const getDefaultCurrencyForBlock = (
+  blockType: BlockType,
+  userNationality?: string,
+  planLocation?: string
+): CurrencyCode => {
+  switch (blockType) {
+    case 'flight':
+      // 항공료는 사용자 국적 기준 (한국인이면 KRW로 결제)
+      return getCurrencyFromNationality(userNationality);
+    case 'hotel':
+    case 'food':
+    case 'activity':
+    case 'move':
+    case 'memo':
+    default:
+      // 현지 활동은 목적지 통화 (없으면 사용자 국적 기준)
+      return (
+        getCurrencyFromLocation(planLocation) ||
+        getCurrencyFromNationality(userNationality)
+      );
+  }
+};
+
+/**
+ * 위치에 따른 통화 추론 (기존 함수 확장)
+ */
+const getCurrencyFromLocation = (location?: string): CurrencyCode | null => {
+  if (!location) return null;
+
+  const locationLower = location.toLowerCase();
+
+  // 주요 국가/도시별 통화 매핑
+  const locationCurrencyMap: Record<string, CurrencyCode> = {
+    // 일본
+    japan: 'JPY',
+    tokyo: 'JPY',
+    osaka: 'JPY',
+    kyoto: 'JPY',
+    일본: 'JPY',
+    도쿄: 'JPY',
+    오사카: 'JPY',
+    교토: 'JPY',
+
+    // 미국
+    usa: 'USD',
+    america: 'USD',
+    'new york': 'USD',
+    'los angeles': 'USD',
+    미국: 'USD',
+    뉴욕: 'USD',
+
+    // 유럽
+    paris: 'EUR',
+    london: 'GBP',
+    rome: 'EUR',
+    berlin: 'EUR',
+    파리: 'EUR',
+    런던: 'GBP',
+    로마: 'EUR',
+    베를린: 'EUR',
+
+    // 동남아시아
+    thailand: 'THB',
+    bangkok: 'THB',
+    태국: 'THB',
+    방콕: 'THB',
+    vietnam: 'VND',
+    'ho chi minh': 'VND',
+    베트남: 'VND',
+    호치민: 'VND',
+    singapore: 'SGD',
+    싱가포르: 'SGD',
+    malaysia: 'MYR',
+    'kuala lumpur': 'MYR',
+    말레이시아: 'MYR',
+
+    // 중국
+    china: 'CNY',
+    beijing: 'CNY',
+    shanghai: 'CNY',
+    중국: 'CNY',
+    베이징: 'CNY',
+    상하이: 'CNY',
+
+    // 기타
+    taiwan: 'TWD',
+    taipei: 'TWD',
+    대만: 'TWD',
+    타이베이: 'TWD',
+    'hong kong': 'HKD',
+    홍콩: 'HKD',
+    australia: 'AUD',
+    sydney: 'AUD',
+    호주: 'AUD',
+    시드니: 'AUD',
+  };
+
+  for (const [key, currency] of Object.entries(locationCurrencyMap)) {
+    if (locationLower.includes(key)) {
+      return currency;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * 블록 타입별 기본 소요시간 (분 단위)
+ */
+export const getDefaultDuration = (blockType: BlockType): number => {
+  const durations: Record<BlockType, number> = {
+    flight: 120, // 2시간 (평균 국제선)
+    hotel: 0, // 체크인만 (시간 범위 없음)
+    food: 90, // 1시간 30분
+    activity: 180, // 3시간
+    move: 30, // 30분
+    memo: 0, // 메모는 시간 없음
+  };
+
+  return durations[blockType] || 0;
+};
+
+/**
+ * 시간에 분 추가하는 헬퍼 함수
+ */
+export const addMinutes = (timeString: string, minutes: number): string => {
+  if (!timeString) return '';
+
+  const [hours, mins] = timeString.split(':').map(Number);
+  const totalMinutes = hours * 60 + mins + minutes;
+
+  const newHours = Math.floor(totalMinutes / 60) % 24;
+  const newMins = totalMinutes % 60;
+
+  return `${newHours.toString().padStart(2, '0')}:${newMins.toString().padStart(2, '0')}`;
+};
+
+/**
+ * 소요시간을 사람이 읽기 쉬운 형태로 포맷
+ */
+export const formatDuration = (minutes: number): string => {
+  if (minutes < 60) {
+    return `${minutes}분`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (remainingMinutes === 0) {
+    return `${hours}시간`;
+  }
+
+  return `${hours}시간 ${remainingMinutes}분`;
+};
+
+/**
+ * 블록 타입별 설정 정보
+ */
+export const blockTypeConfigs = [
+  {
+    type: 'flight' as BlockType,
+    label: '항공',
+    icon: '✈️',
+    gradient: 'from-sky-400 to-blue-500',
+    description: '항공편 예약',
+    color: 'text-sky-600',
+    bgColor: 'bg-sky-50',
+  },
+  {
+    type: 'hotel' as BlockType,
+    label: '숙소',
+    icon: '🏨',
+    gradient: 'from-purple-400 to-pink-500',
+    description: '호텔 & 숙박',
+    color: 'text-purple-600',
+    bgColor: 'bg-purple-50',
+  },
+  {
+    type: 'food' as BlockType,
+    label: '식사',
+    icon: '🍽️',
+    gradient: 'from-orange-400 to-red-500',
+    description: '맛집 & 레스토랑',
+    color: 'text-orange-600',
+    bgColor: 'bg-orange-50',
+  },
+  {
+    type: 'activity' as BlockType,
+    label: '관광',
+    icon: '🎯',
+    gradient: 'from-green-400 to-emerald-500',
+    description: '관광 & 액티비티',
+    color: 'text-green-600',
+    bgColor: 'bg-green-50',
+  },
+  {
+    type: 'move' as BlockType,
+    label: '이동',
+    icon: '🚗',
+    gradient: 'from-blue-400 to-indigo-500',
+    description: '교통 & 이동',
+    color: 'text-blue-600',
+    bgColor: 'bg-blue-50',
+  },
+  {
+    type: 'memo' as BlockType,
+    label: '메모',
+    icon: '📝',
+    gradient: 'from-gray-400 to-gray-500',
+    description: '메모 & 참고사항',
+    color: 'text-gray-600',
+    bgColor: 'bg-gray-50',
+  },
+];
+
+/**
+ * 블록 타입별 라벨 반환
+ */
+export const getBlockTypeLabel = (blockType: BlockType): string => {
+  const config = blockTypeConfigs.find((c) => c.type === blockType);
+  return config?.label || blockType;
+};
+
+/**
+ * 사용자 국적별 주요 출발 공항 제안
+ */
+export const getDepartureAirportSuggestions = (
+  nationality?: string
+): string[] => {
+  const suggestions: Record<string, string[]> = {
+    KR: [
+      '인천국제공항 (ICN)',
+      '김포공항 (GMP)',
+      '부산 김해공항 (PUS)',
+      '제주공항 (CJU)',
+    ],
+    JP: [
+      '나리타공항 (NRT)',
+      '하네다공항 (HND)',
+      '간사이공항 (KIX)',
+      '주부공항 (NGO)',
+    ],
+    US: [
+      'JFK공항 (JFK)',
+      'LAX공항 (LAX)',
+      '오헤어공항 (ORD)',
+      '마이애미공항 (MIA)',
+    ],
+    CN: [
+      '베이징 수도공항 (PEK)',
+      '상하이 푸동공항 (PVG)',
+      '광저우공항 (CAN)',
+      '선전공항 (SZX)',
+    ],
+  };
+
+  return suggestions[nationality?.toUpperCase() || 'KR'] || suggestions.KR;
+};
+
+/**
+ * 목적지별 주요 도착 공항 제안
+ */
+export const getArrivalAirportSuggestions = (location?: string): string[] => {
+  if (!location) return [];
+
+  const locationLower = location.toLowerCase();
+
+  const suggestions: Record<string, string[]> = {
+    japan: [
+      '나리타공항 (NRT)',
+      '하네다공항 (HND)',
+      '간사이공항 (KIX)',
+      '주부공항 (NGO)',
+    ],
+    일본: [
+      '나리타공항 (NRT)',
+      '하네다공항 (HND)',
+      '간사이공항 (KIX)',
+      '주부공항 (NGO)',
+    ],
+    thailand: [
+      '수완나품공항 (BKK)',
+      '돈므앙공항 (DMK)',
+      '푸켓공항 (HKT)',
+      '치앙마이공항 (CNX)',
+    ],
+    태국: [
+      '수완나품공항 (BKK)',
+      '돈므앙공항 (DMK)',
+      '푸켓공항 (HKT)',
+      '치앙마이공항 (CNX)',
+    ],
+    vietnam: ['탄손낫공항 (SGN)', '노이바이공항 (HAN)', '다낭공항 (DAD)'],
+    베트남: ['탄손낫공항 (SGN)', '노이바이공항 (HAN)', '다낭공항 (DAD)'],
+    usa: [
+      'JFK공항 (JFK)',
+      'LAX공항 (LAX)',
+      '오헤어공항 (ORD)',
+      '마이애미공항 (MIA)',
+    ],
+    미국: [
+      'JFK공항 (JFK)',
+      'LAX공항 (LAX)',
+      '오헤어공항 (ORD)',
+      '마이애미공항 (MIA)',
+    ],
+  };
+
+  for (const [key, airports] of Object.entries(suggestions)) {
+    if (locationLower.includes(key)) {
+      return airports;
+    }
+  }
+
+  return [];
+};

--- a/apps/web/src/lib/design-tokens.ts
+++ b/apps/web/src/lib/design-tokens.ts
@@ -1,0 +1,90 @@
+export const designTokens = {
+  colors: {
+    primary: {
+      50: '#eff6ff',
+      100: '#dbeafe',
+      200: '#bfdbfe',
+      300: '#93c5fd',
+      400: '#60a5fa',
+      500: '#3b82f6',
+      600: '#2563eb',
+      700: '#1d4ed8',
+      800: '#1e40af',
+      900: '#1e3a8a',
+    },
+    success: {
+      50: '#f0fdf4',
+      100: '#dcfce7',
+      500: '#22c55e',
+      600: '#16a34a',
+    },
+    warning: {
+      50: '#fffbeb',
+      100: '#fef3c7',
+      500: '#f59e0b',
+      600: '#d97706',
+    },
+    error: {
+      50: '#fef2f2',
+      100: '#fee2e2',
+      500: '#ef4444',
+      600: '#dc2626',
+    },
+    gray: {
+      50: '#f9fafb',
+      100: '#f3f4f6',
+      200: '#e5e7eb',
+      300: '#d1d5db',
+      400: '#9ca3af',
+      500: '#6b7280',
+      600: '#4b5563',
+      700: '#374151',
+      800: '#1f2937',
+      900: '#111827',
+    },
+  },
+  gradients: {
+    flight: 'from-sky-400 to-blue-500',
+    hotel: 'from-purple-400 to-pink-500',
+    food: 'from-orange-400 to-red-500',
+    activity: 'from-green-400 to-emerald-500',
+    move: 'from-blue-400 to-indigo-500',
+    memo: 'from-gray-400 to-gray-500',
+  },
+  shadows: {
+    card: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+    cardHover:
+      '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06)',
+    modal: '0 25px 50px -12px rgb(0 0 0 / 0.25)',
+    button: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  },
+  borderRadius: {
+    sm: '0.5rem',
+    md: '0.75rem',
+    lg: '1rem',
+    xl: '1.25rem',
+    '2xl': '1.5rem',
+    '3xl': '1.75rem',
+  },
+  spacing: {
+    xs: '0.5rem',
+    sm: '0.75rem',
+    md: '1rem',
+    lg: '1.5rem',
+    xl: '2rem',
+    '2xl': '3rem',
+  },
+  animation: {
+    spring: {
+      type: 'spring',
+      stiffness: 300,
+      damping: 25,
+    },
+    smooth: {
+      duration: 0.3,
+      ease: [0.4, 0, 0.2, 1],
+    },
+  },
+} as const;
+
+export type DesignTokens = typeof designTokens;

--- a/apps/web/src/types/travel/travel.ts
+++ b/apps/web/src/types/travel/travel.ts
@@ -137,7 +137,7 @@ export interface UpdateTodoRequest {
   title?: string;
   description?: string;
   is_completed?: boolean;
-  assigned_user_id?: string;
+  assigned_user_id?: string | null;
   due_date?: string;
   priority?: TodoPriority;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.507.0",
+    "framer-motion": "^12.11.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -10,3 +10,4 @@ export * from './badge';
 export * from './spinner';
 export * from './avatar';
 export * from './progress';
+export * from './select';

--- a/packages/ui/src/components/select/index.ts
+++ b/packages/ui/src/components/select/index.ts
@@ -1,0 +1,1 @@
+export * from './select';

--- a/packages/ui/src/components/select/select.tsx
+++ b/packages/ui/src/components/select/select.tsx
@@ -1,0 +1,461 @@
+'use client';
+
+import * as React from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import { cn } from '@ui/utils/cn';
+
+// 아이콘 컴포넌트 (가독성을 위해 내부에 정의)
+const CheckIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='16'
+    height='16'
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='3'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    {...props}
+  >
+    <polyline points='20 6 9 17 4 12' />
+  </svg>
+);
+
+const ChevronDownIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='16'
+    height='16'
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='2'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    {...props}
+  >
+    <path d='m6 9 6 6 6-6' />
+  </svg>
+);
+
+const XIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='12'
+    height='12'
+    viewBox='0 0 24 24'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='2.5'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    {...props}
+  >
+    <path d='M18 6 6 18' />
+    <path d='m6 6 12 12' />
+  </svg>
+);
+
+// 컴포넌트 타입 정의
+export type SelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export interface MultiSelectProps {
+  /** 라벨 텍스트 */
+  label: string;
+  /** 선택된 값들의 배열 */
+  value: string[];
+  /** 값 변경 시 호출되는 콜백 함수 */
+  onChange: (value: string[]) => void;
+  /** 선택 가능한 옵션 목록 */
+  options: SelectOption[];
+  /** 아무것도 선택되지 않았을 때 표시될 텍스트 */
+  placeholder?: string;
+  /** 필수 입력 여부 */
+  required?: boolean;
+  /** 컴포넌트 비활성화 여부 */
+  disabled?: boolean;
+  /** 에러 메시지 */
+  error?: string;
+  /** 추가적인 Tailwind CSS 클래스 */
+  className?: string;
+  /** 라벨 애니메이션 비활성화 */
+  disableLabelAnimation?: boolean;
+  /** 선택된 항목을 보여주는 최대 개수. 초과 시 "+N"으로 표시됩니다. */
+  maxDisplay?: number;
+}
+
+export const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
+  (props, ref) => {
+    const {
+      label,
+      value = [],
+      onChange,
+      options,
+      placeholder = '선택...',
+      required = false,
+      disabled,
+      error,
+      className,
+      disableLabelAnimation = false,
+      maxDisplay = 3,
+    } = props;
+
+    const [isFocused, setIsFocused] = React.useState(false);
+    const [isOpen, setIsOpen] = React.useState(false);
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
+    const hasValue = value.length > 0;
+    const shouldFloat = hasValue || isFocused || isOpen;
+
+    // 외부 클릭 감지하여 드롭다운 닫기
+    React.useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (
+          containerRef.current &&
+          !containerRef.current.contains(event.target as Node)
+        ) {
+          setIsOpen(false);
+          setIsFocused(false);
+        }
+      };
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }, []);
+
+    // 옵션 선택/해제 핸들러
+    const handleSelect = (optionValue: string) => {
+      if (disabled) return;
+      const newValue = value.includes(optionValue)
+        ? value.filter((v) => v !== optionValue)
+        : [...value, optionValue];
+      onChange(newValue);
+    };
+
+    // 칩(Chip)의 'x' 버튼 클릭 핸들러
+    const handleRemove = (
+      e: React.MouseEvent<HTMLButtonElement>,
+      valueToRemove: string
+    ) => {
+      e.stopPropagation(); // 이벤트 버블링 방지
+      if (disabled) return;
+      onChange(value.filter((v) => v !== valueToRemove));
+    };
+
+    const selectedOptions = React.useMemo(
+      () => options.filter((opt) => value.includes(opt.value)),
+      [options, value]
+    );
+
+    return (
+      <div className={cn('relative', className)} ref={containerRef}>
+        {/* 선택 영역 (Trigger) */}
+        <button
+          type='button'
+          ref={ref as React.Ref<HTMLButtonElement>}
+          disabled={disabled}
+          onClick={() => !disabled && setIsOpen(!isOpen)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => {
+            setIsFocused(false);
+            setTimeout(() => setIsOpen(false), 150);
+          }}
+          className={cn(
+            'peer w-full rounded-2xl border-2 bg-gray-50/50 px-4 text-gray-900 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0',
+            shouldFloat ? 'pb-2 pt-6' : 'pb-4 pt-4',
+            hasValue ? 'border-gray-300' : 'border-gray-200',
+            disabled
+              ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+              : 'hover:border-gray-300',
+            error && 'border-red-500 focus:border-red-500'
+          )}
+        >
+          <div className='flex flex-wrap items-center gap-1.5'>
+            {selectedOptions.length === 0 ? (
+              <span
+                className={cn(
+                  'text-left',
+                  !hasValue && !isFocused && 'text-gray-400'
+                )}
+              >
+                {placeholder}
+              </span>
+            ) : (
+              <>
+                {selectedOptions.slice(0, maxDisplay).map((opt) => (
+                  <div
+                    key={opt.value}
+                    className={cn(
+                      'flex items-center gap-1.5 rounded-md bg-blue-50 px-2 py-1 text-sm font-medium text-blue-700',
+                      { 'bg-gray-100 text-gray-500': disabled }
+                    )}
+                  >
+                    {opt.label}
+                    {!disabled && (
+                      <button
+                        type='button'
+                        onClick={(e) => handleRemove(e, opt.value)}
+                        className='rounded-full hover:bg-blue-200'
+                      >
+                        <XIcon className='h-3 w-3 text-blue-700' />
+                      </button>
+                    )}
+                  </div>
+                ))}
+                {selectedOptions.length > maxDisplay && (
+                  <div className='rounded-md bg-gray-100 px-2 py-1 text-sm font-medium text-gray-600'>
+                    +{selectedOptions.length - maxDisplay}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+          <ChevronDownIcon
+            className={cn(
+              'absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 transition-transform',
+              isOpen && 'rotate-180'
+            )}
+          />
+        </button>
+
+        {/* 플로팅 라벨 */}
+        {disableLabelAnimation ? (
+          <label className='pointer-events-none absolute left-4 top-2 text-xs font-medium text-gray-500'>
+            {label}
+            {required && <span className='ml-1 text-red-500'>*</span>}
+          </label>
+        ) : (
+          <motion.label
+            animate={{
+              top: shouldFloat ? '0.5rem' : '1rem',
+              fontSize: shouldFloat ? '0.75rem' : '1rem',
+              color: isFocused ? '#3b82f6' : hasValue ? '#6b7280' : '#9ca3af',
+            }}
+            transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
+            className='pointer-events-none absolute left-4 origin-left font-medium'
+          >
+            {label}
+            {required && <span className='ml-1 text-red-500'>*</span>}
+          </motion.label>
+        )}
+
+        {/* 드롭다운 메뉴 */}
+        <AnimatePresence>
+          {isOpen && !disabled && (
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.15 }}
+              className='absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg'
+            >
+              {options.map((opt) => {
+                const isSelected = value.includes(opt.value);
+                return (
+                  <button
+                    key={opt.value}
+                    type='button'
+                    onClick={() => !opt.disabled && handleSelect(opt.value)}
+                    disabled={opt.disabled}
+                    className={cn(
+                      'flex w-full items-center justify-between px-4 py-3 text-left text-sm transition-colors first:rounded-t-xl last:rounded-b-xl',
+                      {
+                        'bg-blue-50 text-blue-700': isSelected,
+                        'hover:bg-gray-50 focus:bg-blue-50 focus:outline-none':
+                          !opt.disabled && !isSelected,
+                        'cursor-not-allowed text-gray-400': opt.disabled,
+                      }
+                    )}
+                  >
+                    <span>{opt.label}</span>
+                    {isSelected && (
+                      <CheckIcon className='h-4 w-4 text-blue-700' />
+                    )}
+                  </button>
+                );
+              })}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* 에러 메시지 */}
+        {error && (
+          <motion.p
+            initial={{ opacity: 0, y: -5 }}
+            animate={{ opacity: 1, y: 0 }}
+            className='mt-1 text-xs text-red-600'
+          >
+            {error}
+          </motion.p>
+        )}
+      </div>
+    );
+  }
+);
+
+MultiSelect.displayName = 'MultiSelect';
+
+// [시작] Select 컴포넌트 수정 영역
+export interface SelectProps {
+  label: string;
+  value: string | undefined;
+  onChange?: (value: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  required?: boolean;
+  disabled?: boolean;
+  error?: string;
+  className?: string;
+  // disableLabelAnimation prop 제거
+}
+
+export const Select = React.forwardRef<HTMLDivElement, SelectProps>(
+  (
+    {
+      label,
+      value,
+      onChange,
+      options,
+      placeholder,
+      required = false,
+      disabled = false,
+      error,
+      className = '',
+      // disableLabelAnimation prop 제거
+    },
+    ref
+  ) => {
+    const [isFocused, setIsFocused] = React.useState(false);
+    const [isOpen, setIsOpen] = React.useState(false);
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
+    const hasValue = Boolean(value);
+    const shouldFloat = hasValue || isFocused || isOpen;
+
+    React.useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (
+          containerRef.current &&
+          !containerRef.current.contains(event.target as Node)
+        ) {
+          setIsOpen(false);
+          setIsFocused(false);
+        }
+      };
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }, []);
+
+    const handleSelect = (optionValue: string) => {
+      if (disabled) return;
+      onChange?.(optionValue);
+      setIsOpen(false);
+      setIsFocused(false);
+    };
+
+    const selectedOption = options.find((opt) => opt.value === value);
+
+    return (
+      <div className={cn('relative', className)} ref={containerRef}>
+        {/* 선택 영역 (Trigger) */}
+        <button
+          type='button'
+          ref={ref as React.Ref<HTMLButtonElement>}
+          disabled={disabled}
+          onClick={() => !disabled && setIsOpen(!isOpen)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => {
+            setIsFocused(false);
+            setTimeout(() => setIsOpen(false), 150);
+          }}
+          className={cn(
+            'peer w-full rounded-2xl border-2 bg-gray-50/50 px-4 text-left text-gray-900 transition-all focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-0',
+            'pb-2 pt-6',
+            hasValue ? 'border-gray-300' : 'border-gray-200',
+            disabled
+              ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+              : 'hover:border-gray-300',
+            error && 'border-red-500 focus:border-red-500'
+          )}
+        >
+          <div className='flex items-center justify-between'>
+            <span className={cn('text-left', !hasValue && 'text-gray-400')}>
+              {selectedOption?.label ||
+                (shouldFloat ? placeholder || '선택하세요' : <>&nbsp;</>)}
+            </span>
+            <ChevronDownIcon
+              className={cn(
+                'h-4 w-4 text-gray-400 transition-transform',
+                isOpen && 'rotate-180'
+              )}
+            />
+          </div>
+        </button>
+
+        <label className='pointer-events-none absolute left-4 top-2 text-xs font-medium text-gray-500'>
+          {label}
+          {required && <span className='ml-1 text-red-500'>*</span>}
+        </label>
+
+        {/* 드롭다운 메뉴 */}
+        <AnimatePresence>
+          {isOpen && !disabled && (
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.15 }}
+              className='absolute left-0 right-0 top-full z-10 mt-1 max-h-48 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg'
+            >
+              {options.map((opt) => (
+                <button
+                  key={opt.value}
+                  type='button'
+                  onClick={() => !opt.disabled && handleSelect(opt.value)}
+                  disabled={opt.disabled}
+                  className={cn(
+                    'flex w-full items-center justify-between px-4 py-3 text-left text-sm transition-colors first:rounded-t-xl last:rounded-b-xl',
+                    {
+                      'bg-blue-50 text-blue-700': value === opt.value,
+                      'hover:bg-gray-50 focus:bg-blue-50 focus:outline-none':
+                        !opt.disabled && value !== opt.value,
+                      'cursor-not-allowed text-gray-400': opt.disabled,
+                    }
+                  )}
+                >
+                  <span>{opt.label}</span>
+                  {value === opt.value && (
+                    <CheckIcon className='h-4 w-4 text-blue-700' />
+                  )}
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* 에러 메시지 */}
+        {error && (
+          <motion.p
+            initial={{ opacity: 0, y: -5 }}
+            animate={{ opacity: 1, y: 0 }}
+            className='mt-1 text-xs text-red-600'
+          >
+            {error}
+          </motion.p>
+        )}
+      </div>
+    );
+  }
+);
+
+Select.displayName = 'Select';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
       '@storybook/nextjs':
         specifier: 8.6.12
-        version: 8.6.12(esbuild@0.25.4)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8(esbuild@0.25.4))
+        version: 8.6.12(esbuild@0.25.4)(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8(esbuild@0.25.4))
       '@storybook/react':
         specifier: 8.6.12
         version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
@@ -249,7 +249,7 @@ importers:
         version: 10.0.0
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        version: 1.5.0(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       autoprefixer:
         specifier: ^10.0.1
         version: 10.4.21(postcss@8.5.3)
@@ -267,7 +267,7 @@ importers:
         version: 15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-intl:
         specifier: ^4.1.0
         version: 4.1.0(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -319,7 +319,7 @@ importers:
         version: 8.6.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))
       '@storybook/nextjs':
         specifier: ^8.6.12
-        version: 8.6.12(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8)
+        version: 8.6.12(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8)
       '@storybook/react':
         specifier: ^8.6.12
         version: 8.6.12(@storybook/test@8.6.12(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
@@ -362,9 +362,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      lucide-react:
-        specifier: ^0.507.0
-        version: 0.507.0(react@19.1.0)
+      framer-motion:
+        specifier: ^12.11.3
+        version: 12.11.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -4415,11 +4415,6 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lucide-react@0.507.0:
-    resolution: {integrity: sha512-XfgE6gvAHwAtnbUvWiTTHx4S3VGR+cUJHEc0vrh9Ogu672I1Tue2+Cp/8JJqpytgcBHAB1FVI297W4XGNwc2dQ==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -7858,7 +7853,7 @@ snapshots:
     dependencies:
       storybook: 8.6.12(prettier@3.5.3)
 
-  '@storybook/nextjs@8.6.12(esbuild@0.25.4)(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8(esbuild@0.25.4))':
+  '@storybook/nextjs@8.6.12(esbuild@0.25.4)(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8(esbuild@0.25.4))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.27.1)
@@ -7923,7 +7918,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/nextjs@8.6.12(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8)':
+  '@storybook/nextjs@8.6.12(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(type-fest@2.19.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.99.8)':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.27.1)
@@ -8616,7 +8611,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.7.2':
     optional: true
 
-  '@vercel/analytics@1.5.0(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@vercel/analytics@1.5.0(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     optionalDependencies:
       next: 15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
@@ -9813,7 +9808,7 @@ snapshots:
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.26.0(jiti@2.4.2))
@@ -9847,7 +9842,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@9.26.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -9876,14 +9871,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.3.4(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -9916,7 +9911,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -9927,7 +9922,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11098,10 +11093,6 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react@0.507.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.17:
@@ -11214,7 +11205,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@4.24.11(next@15.3.1(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-auth@4.24.11(next@15.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.1
       '@panva/hkdf': 1.2.1


### PR DESCRIPTION
feat: 여행 대시보드 및 블록 관리 기능 확장

📝 설명  
여행 대시보드와 상세 페이지의 UI/UX를 전반적으로 개선하고,  
블록 CRUD/편집/삭제 기능 및 공동 할일 담당자 지정 기능을 추가했습니다.  
여행 정보 수정과 권한 기반  협업 기능 개발을 했습니다.
API 구조 개선과 새로운 Select 컴포넌트를 도입했습니다.

🚀 주요 변경사항  
- **대시보드/위젯 개선**  
  - "모든 항목 보기" 버튼 및 반응형 모달 추가  
  - 최근 변경사항 위젯: 최대 3개 제한, 전체 보기 모달 구현  
  - 빈 상태/모바일 반응형 레이아웃 개선  

- **블록 관리 강화**  
  - 블록 생성/수정/삭제 기능 구현 (BlockCreateModal 통합)  
  - 블록 세부정보 모달에서 수정 버튼 연결  
  - 항공편 메타 데이터(from/to) 자동 처리  
  - 호텔 블록: 불필요 필드 제거(roomType, 시간 입력)  

- **공동 할 일**  
  - 담당자 할당/해제 기능 추가  

- **여행 정보 관리**  
  - 여행 제목/날짜/예산 수정 기능 추가 (TravelEditInfoModal)  
  - PUT `/api/travel/:id` 엔드포인트 구현  
  - 오너만 접근 가능한 빠른 액션 블록 제어  

- **UI/UX 및 입력 개선**  
  - 커스텀 Select/MultiSelect 컴포넌트 도입 및 스토리 작성  
  - Block Detail Modal → 새 Select API 반영 및 readonly 정리  
  - TimerangePicker에 추천 소요시간 프리셋 추가  
  - 일정 카드 UX 개선: 본문 클릭=상세, 아이콘 클릭=편집  

- **API/클라이언트 개선**  
  - 블록 API: JSONB 필드 정규화(location, time_range, cost)  
  - 오너/에디터 권한 체크 강화, 에러 응답에 details/hint/code 포함  
  - 클라이언트 API: updateBlock 에러 로깅 및 타입 안정성 개선  

- **기타**  
  - 여행 생성 후 목록 즉시 반영 (쿼리 무효화)  
  - 여행 상세 데이터 최신화 로직 보강  
  - 레이아웃/헤더 개선, 패키지 정리 및 lockfile 업데이트